### PR TITLE
Make sure that we set the cache path to a subfolder

### DIFF
--- a/obs-browser/browser-manager-base.cpp
+++ b/obs-browser/browser-manager-base.cpp
@@ -413,7 +413,7 @@ void BrowserManager::Impl::BrowserManagerEntry()
 		settings.log_severity = LOGSEVERITY_VERBOSE;
 		settings.windowless_rendering_enabled = true;
 		settings.no_sandbox = true;
-		CefString(&settings.cache_path).FromASCII(obs_module_config_path(""));
+		CefString(&settings.cache_path).FromASCII(obs_module_config_path("cache"));
 		CefString(&settings.browser_subprocess_path) = getBootstrap();
 		CefRefPtr<BrowserApp> app(new BrowserApp());
 		CefExecuteProcess(mainArgs, app, nullptr);


### PR DESCRIPTION
When running in debug chrome does a DCHECK on partition and profile path.

https://chromium.googlesource.com/experimental/chromium/src/+/refs/wip/bajones/webvr/chrome/browser/ui/zoom/chrome_zoom_level_prefs.cc#44