### PR TITLE
obs-browser: bugfix: don't paint invisible sources

### DIFF
--- a/obs-browser/main-source.cpp
+++ b/obs-browser/main-source.cpp
@@ -176,12 +176,18 @@ static void browser_source_show(void *data)
 	else {
 		bs->ExecuteVisiblityJSCallback(true);
 	}
+
+	// Start animation
+	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->WasHidden(false);
 }
 
 // Called when the source is no longer visible
 static void browser_source_hide(void *data)
 {
 	BrowserSource *bs = static_cast<BrowserSource *>(data);
+
+	// Stop animation
+	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->WasHidden(true);
 
 	if (bs->GetShutdown()) {
 		BrowserManager::Instance()->DestroyBrowser(bs->GetBrowserIdentifier());

--- a/obs-browser/main-source.cpp
+++ b/obs-browser/main-source.cpp
@@ -179,6 +179,13 @@ static void browser_source_show(void *data)
 
 	// Start animation
 	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->WasHidden(false);
+
+#ifdef APPLE
+	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->SetWindowVisibility(true);
+#endif
+
+	// Repaint the view
+	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->Invalidate(PET_VIEW);
 }
 
 // Called when the source is no longer visible
@@ -188,6 +195,10 @@ static void browser_source_hide(void *data)
 
 	// Stop animation
 	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->WasHidden(true);
+
+#ifdef APPLE
+	BrowserManager::Instance()->GetBrowser(bs->GetBrowserIdentifier())->GetHost()->SetWindowVisibility(false);
+#endif
 
 	if (bs->GetShutdown()) {
 		BrowserManager::Instance()->DestroyBrowser(bs->GetBrowserIdentifier());


### PR DESCRIPTION
WasHidden(false) prevents OnDraw() calls from being
made on hidden sources.
This saves CPU cycles on sources which are hidden.
