### PR TITLE
obs-browser: do not paint for released BrowserSources

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -132,7 +132,7 @@ bool BrowserClient::GetViewRect(
 }
 
 void BrowserClient::OnPaint(
-		CefRefPtr<CefBrowser>,
+		CefRefPtr<CefBrowser> cefBrowser,
 		PaintElementType type,
 		const RectList &,
 		const void *buffer,
@@ -140,6 +140,12 @@ void BrowserClient::OnPaint(
 		int height)
 {
 	if (type != PET_VIEW) {
+		return;
+	}
+
+	if (!static_cast<BrowserClient*>(
+		cefBrowser->GetHost()->GetClient().get())->isValid) {
+		// The browser has been destroyed
 		return;
 	}
 
@@ -175,12 +181,18 @@ void BrowserClient::OnPaint(
 
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
 void BrowserClient::OnAcceleratedPaint(
-		CefRefPtr<CefBrowser>,
+		CefRefPtr<CefBrowser> cefBrowser,
 		PaintElementType type,
 		const RectList &,
 		void *shared_handle,
 		uint64)
 {
+	if (!static_cast<BrowserClient*>(
+		cefBrowser->GetHost()->GetClient().get())->isValid) {
+		// The browser has been destroyed
+		return;
+	}
+
 	if (shared_handle != last_handle) {
 		obs_enter_graphics();
 		gs_texture_destroy(texture);

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -42,8 +42,13 @@ public:
 	CefRect popupRect;
 	CefRect originalPopupRect;
 
+	// This flag is checked by BrowserClient::OnPaint and
+	// BrowserClient::OnAcceleratedPaint
+	// If its value is false, the paint events are discarded.
+	bool isValid;
+
 	inline BrowserClient(BrowserSource *bs_, bool sharing_avail)
-		: bs(bs_)
+		: bs(bs_), isValid(true)
 	{
 		sharing_available = sharing_avail;
 	}

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -126,6 +126,13 @@ void BrowserSource::DestroyBrowser(bool async)
 {
 	ExecuteOnBrowser([this] ()
 	{
+		// Mark the BrowserClient as INVALID
+		//
+		// This is checked by BrowserClient::OnPaint and BrowserClient::OnAcceleratedPaint
+		static_cast<BrowserClient*>(
+			cefBrowser->GetHost()->GetClient().get())->isValid =
+				false;
+
 		/*
 		 * This stops rendering
 		 * http://magpcss.org/ceforum/viewtopic.php?f=6&t=12079


### PR DESCRIPTION
BrowserClient::OnPaint() and BrowserClient::OnAcceleratedPaint() events
can arrive even after calling BrowserSource::DestroyBrowser().
This adds a check whether the BrowserClient identified by the
CefBrowser passed to OnPaint() and OnAcceleratedPaint() is still
valid without introducing global locks.