### PR TITLE
Log plugin version on module load

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -28,6 +28,7 @@
 #include "obs-browser-source.hpp"
 #include "browser-scheme.hpp"
 #include "browser-app.hpp"
+#include "browser-version.h"
 
 #include "json11/json11.hpp"
 #include "cef-headers.hpp"
@@ -346,6 +347,8 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 
 bool obs_module_load(void)
 {
+	blog(LOG_INFO, "[obs-browser]: Version %s",
+			OBS_BROWSER_VERSION_STRING);
 	RegisterBrowserSource();
 	obs_frontend_add_event_callback(handle_obs_frontend_event, nullptr);
 	return true;


### PR DESCRIPTION
In the browser source rewrite, the log line showing the plugin version number seems to have gotten lost.  I personally think all plugins should display their version number clearly in the log, so I'd like to see this added back in.  I've changed the log message a bit to be more similar to other plugins' log messages.

I'm not sure if it would be better to include browser-version.h in browser-app.hpp instead of directly including it here (and in browser-app.cpp, apparently).

Compiled and tested a 64-bit build on Windows 10 64-bit.