### PR TITLE
Check whether or not we're showing when creating a browser

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -365,7 +365,9 @@ void BrowserSource::Update(obs_data_t *settings)
 
 	DestroyBrowser(true);
 	DestroyTextures();
-	create_browser = true;
+
+	if (!shutdown_on_invisible || obs_source_showing(source))
+		create_browser = true;
 }
 
 void BrowserSource::Tick()


### PR DESCRIPTION
Somehow [this issue](https://github.com/obsproject/obs-browser/issues/101) made it through the refactor. The Qt OBS UI doesn't have this issue (for reasons I haven't explored) but if you make a browser source that isn't considered showing on the current scene, it will still create the browser source. 