### PR TITLE
Revise FindCEF to use imported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,17 +23,14 @@ configure_file(
 	"${CMAKE_CURRENT_BINARY_DIR}/browser-config.h")
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
-include_directories("${CEF_ROOT_DIR}")
 
 # ----------------------------------------------------------------------------
 
 set(obs-browser_LIBRARIES
+	CEF::CEF
 	libobs
 	obs-frontend-api
 	)
-
-list(APPEND obs-browser_LIBRARIES
-	${CEF_LIBRARIES})
 
 if(MSVC)
 	string(REPLACE "/MD" "/MT"
@@ -139,9 +136,7 @@ add_executable(cef-bootstrap
 	${cef-bootstrap_SOURCES}
 	${cef-bootstrap_HEADERS}
 	)
-target_link_libraries(cef-bootstrap
-	${CEF_LIBRARIES}
-	)
+target_link_libraries(cef-bootstrap	CEF::CEF)
 
 if (APPLE)
 	set_target_properties(cef-bootstrap PROPERTIES

--- a/FindCEF.cmake
+++ b/FindCEF.cmake
@@ -1,52 +1,96 @@
 include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
 
-SET(CEF_ROOT_DIR "" CACHE PATH "Path to a CEF distributed build")
+set(CEF_ROOT_DIR "" CACHE PATH "Path to a CEF distributed build")
+set(CEF_WRAPPER_ROOT_DIR "" CACHE PATH "Path to a CEF dll wrapper build directory")
 
 message(STATUS "Looking for Chromium Embedded Framework in ${CEF_ROOT_DIR}")
 
 find_path(CEF_INCLUDE_DIR "include/cef_version.h"
 	HINTS ${CEF_ROOT_DIR})
 
-find_library(CEF_LIBRARY
+find_library(CEF_LIBRARY_RELEASE
 	NAMES cef libcef cef.lib libcef.o "Chromium Embedded Framework"
 	PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Release)
+
 find_library(CEF_LIBRARY_DEBUG
 	NAMES cef libcef cef.lib libcef.o "Chromium Embedded Framework"
 	PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Debug)
 
-find_library(CEFWRAPPER_LIBRARY
+find_library(CEF_WRAPPER_LIBRARY_RELEASE
 	NAMES cef_dll_wrapper libcef_dll_wrapper
-	PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Release
+	PATHS
+		${CEF_ROOT_DIR}/build/libcef_dll/Release
 		${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release
 		${CEF_ROOT_DIR}/build/libcef_dll
-		${CEF_ROOT_DIR}/build/libcef_dll_wrapper)
-find_library(CEFWRAPPER_LIBRARY_DEBUG
+		${CEF_ROOT_DIR}/build/libcef_dll_wrapper
+		${CEF_WRAPPER_ROOT_DIR}
+		${CEF_WRAPPER_ROOT_DIR}/Release)
+
+find_library(CEF_WRAPPER_LIBRARY_DEBUG
 	NAMES cef_dll_wrapper libcef_dll_wrapper
-	PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Debug ${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Debug)
+	PATHS
+		${CEF_ROOT_DIR}/build/libcef_dll/Debug
+		${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Debug
+		${CEF_WRAPPER_ROOT_DIR}/Debug)
 
-if(NOT CEF_LIBRARY)
-	message(WARNING "Could not find the CEF shared library" )
-	set(CEF_FOUND FALSE)
-	return()
+find_package_handle_standard_args(
+	CEF
+	DEFAULT_MSG
+	CEF_LIBRARY	CEFWRAPPER_LIBRARY CEF_INCLUDE_DIR)
+
+select_library_configurations(CEF)
+select_library_configurations(CEF_WRAPPER)
+
+#Create CEF import target (inspired by Zlib script)
+
+if(NOT TARGET CEF::CEF)
+	add_library(CEF::CEF UNKNOWN IMPORTED)
+	set_target_properties(CEF::CEF PROPERTIES
+		INTERFACE_INCLUDE_DIRECTORIES "${CEF_INCLUDE_DIR}")
+
+	if(CEF_LIBRARY_RELEASE)
+		set_property(TARGET CEF::CEF APPEND PROPERTY
+			IMPORTED_CONFIGURATIONS RELEASE)
+		set_target_properties(CEF::CEF PROPERTIES
+			IMPORTED_LOCATION_RELEASE "${CEF_LIBRARY_RELEASE}")
+	endif()
+
+	if(CEF_LIBRARY_DEBUG)
+		set_property(TARGET CEF::CEF APPEND PROPERTY
+			IMPORTED_CONFIGURATIONS DEBUG)
+		set_target_properties(CEF::CEF PROPERTIES
+			IMPORTED_LOCATION_DEBUG "${CEF_LIBRARY_DEBUG}")
+	endif()
+
+	if(NOT CEF_LIBRARY_RELEASE AND NOT CEF_LIBRARY_DEBUG)
+		set_property(TARGET CEF::CEF APPEND PROPERTY
+			IMPORTED_LOCATION "${CEF_LIBRARY}")
+	endif()
 endif()
 
-if(NOT CEFWRAPPER_LIBRARY)
-	message(WARNING "Could not find the CEF wrapper library" )
-	set(CEF_FOUND FALSE)
-	return()
+if(NOT TARGET CEF::Wrapper)
+	add_library(CEF::Wrapper UNKNOWN IMPORTED)
+
+	if(CEF_WRAPPER_LIBRARY_RELEASE)
+		set_property(TARGET CEF::Wrapper APPEND PROPERTY
+			IMPORTED_CONFIGURATIONS RELEASE)
+		set_target_properties(CEF::Wrapper PROPERTIES
+			IMPORTED_LOCATION_RELEASE "${CEF_WRAPPER_LIBRARY_RELEASE}")
+	endif()
+
+	if(CEF_WRAPPER_LIBRARY_DEBUG)
+		set_property(TARGET CEF::Wrapper APPEND PROPERTY
+			IMPORTED_CONFIGURATIONS DEBUG)
+		set_target_properties(CEF::Wrapper PROPERTIES
+			IMPORTED_LOCATION_DEBUG "${CEF_WRAPPER_LIBRARY_DEBUG}")
+	endif()
+
+	if(NOT CEF_WRAPPER_LIBRARY_RELEASE AND NOT CEF_WRAPPER_LIBRARY_DEBUG)
+		set_property(TARGET CEF::Wrapper APPEND PROPERTY
+			IMPORTED_LOCATION "${CEF_WRAPPER_LIBRARY}")
+	endif()
+
+	set_target_properties(CEF::CEF PROPERTIES
+		INTERFACE_LINK_LIBRARIES CEF::Wrapper)
 endif()
-
-set(CEF_LIBRARIES
-		optimized ${CEFWRAPPER_LIBRARY}
-		optimized ${CEF_LIBRARY})
-
-if (CEF_LIBRARY_DEBUG AND CEFWRAPPER_LIBRARY_DEBUG)
-	list(APPEND CEF_LIBRARIES
-			debug ${CEFWRAPPER_LIBRARY_DEBUG}
-			debug ${CEF_LIBRARY_DEBUG})
-endif()
-
-find_package_handle_standard_args(CEF DEFAULT_MSG CEF_LIBRARY
-	CEFWRAPPER_LIBRARY CEF_INCLUDE_DIR)
-mark_as_advanced(CEF_LIBRARY CEF_WRAPPER_LIBRARY CEF_LIBRARIES
-	CEF_INCLUDE_DIR)


### PR DESCRIPTION
This uses imported targets instead of storing things into variables. There's a few things that are great about imported targets:
1. You don't have to worry about Debug/Release when linking against libraries. You can link against the same target and get the correct version of library. 

2. You don't need to worry about include directories. If you link against the target, Cmake knows you're going to need the include directories to be part of the target you're building in order to use the library.

3. They're easier to specify and safer to use. If the target isn't correctly defined, CMake will give an error where as an empty variable is perfectly acceptable otherwise.

One thing this won't help with is installation. Currently, I'm using install/cpack style rules in order to build libobs distributions. The current CMake script doesn't work for this as it uses copy commands into rundir rather than install commands (so they'll just be excluded from a distribution or cpack build).

This script now works with single-config build systems (make or ninja for instance). The old script didn't because it assumes the Debug/Release paths generated by the default configuration types. It still does to some extent but now the library linked will depend on what's specified. For instance, if it finds the library in "Debug", and our current build type is "Debug", it will use the Debug library. Otherwise, if it only found the Release library, it will use the Release library. If you specify a folder made with Ninja, it will always be the _RELEASE variant and consequently the one always linked against (since there's no practical difference anyways).

