### PR TITLE
Use install commands for consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,34 @@ endif(APPLE AND XCODE)
 
 if (WIN32)
 	math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
-	add_custom_command(TARGET obs-browser POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory
-		"${CEF_ROOT_DIR}/Resources"
-		"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit/"
+
+	install(
+		DIRECTORY "${CEF_ROOT_DIR}/Resources/"
+		DESTINATION "${OBS_PLUGIN_DESTINATION}"
+	)
+
+	install(FILES
+		"${CEF_ROOT_DIR}/Debug/chrome_elf.dll"
+		"${CEF_ROOT_DIR}/Debug/libcef.dll"
+		"${CEF_ROOT_DIR}/Debug/libEGL.dll"
+		"${CEF_ROOT_DIR}/Debug/libGLESv2.dll"
+		"${CEF_ROOT_DIR}/Debug/natives_blob.bin"
+		"${CEF_ROOT_DIR}/Debug/snapshot_blob.bin"
+		"${CEF_ROOT_DIR}/Debug/v8_context_snapshot.bin"
+		DESTINATION "${OBS_PLUGIN_DESTINATION}"
+		CONFIGURATIONS Debug
+	)
+
+	install(FILES
+		"${CEF_ROOT_DIR}/Release/chrome_elf.dll"
+		"${CEF_ROOT_DIR}/Release/libcef.dll"
+		"${CEF_ROOT_DIR}/Release/libEGL.dll"
+		"${CEF_ROOT_DIR}/Release/libGLESv2.dll"
+		"${CEF_ROOT_DIR}/Release/natives_blob.bin"
+		"${CEF_ROOT_DIR}/Release/snapshot_blob.bin"
+		"${CEF_ROOT_DIR}/Release/v8_context_snapshot.bin"
+		DESTINATION "${OBS_PLUGIN_DESTINATION}"
+		CONFIGURATIONS Release RelWithDebInfo MinSizeRel
 	)
 
 	add_custom_command(TARGET obs-browser POST_BUILD


### PR DESCRIPTION
This adds install commands which eases shipping shipping libobs as a distribution or cpack.