### PR TITLE
Add audio capture for browser source

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -61,6 +61,11 @@ CefRefPtr<CefContextMenuHandler> BrowserClient::GetContextMenuHandler()
 	return this;
 }
 
+CefRefPtr<CefAudioHandler> BrowserClient::GetAudioHandler()
+{
+	return this;
+}
+
 bool BrowserClient::OnBeforePopup(
 		CefRefPtr<CefBrowser>,
 		CefRefPtr<CefFrame>,
@@ -248,6 +253,84 @@ void BrowserClient::OnAcceleratedPaint(
 #endif
 }
 #endif
+
+void BrowserClient::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
+		int audio_stream_id_, int channels_,
+		ChannelLayout channel_layout_, int sample_rate_,
+		int frames_per_buffer_)
+{
+	channels = channels_;
+	channel_layout = channel_layout_;
+	sample_rate = sample_rate_;
+	frames_per_buffer = frames_per_buffer_;
+	audio_stream_id = audio_stream_id_;
+}
+
+static speaker_layout getSpeakerLayout(CefAudioHandler::ChannelLayout cefLayout)
+{
+	switch (cefLayout) {
+	case CEF_CHANNEL_LAYOUT_MONO:
+		return SPEAKERS_MONO;      /**< Channels: MONO */
+	case CEF_CHANNEL_LAYOUT_STEREO:
+		return SPEAKERS_STEREO;    /**< Channels: FL, FR */
+	case CEF_CHANNEL_LAYOUT_2POINT1:
+		return SPEAKERS_2POINT1;   /**< Channels: FL, FR, LFE */
+	case CEF_CHANNEL_LAYOUT_2_2:
+	case CEF_CHANNEL_LAYOUT_QUAD:
+	case CEF_CHANNEL_LAYOUT_4_0:
+		return SPEAKERS_4POINT0;   /**< Channels: FL, FR, FC, RC */
+	case CEF_CHANNEL_LAYOUT_4_1:
+		return SPEAKERS_4POINT1;   /**< Channels: FL, FR, FC, LFE, RC */
+	case CEF_CHANNEL_LAYOUT_5_1:
+	case CEF_CHANNEL_LAYOUT_5_1_BACK:
+		return SPEAKERS_5POINT1;   /**< Channels: FL, FR, FC, LFE, RL, RR */
+	case CEF_CHANNEL_LAYOUT_7_1:
+	case CEF_CHANNEL_LAYOUT_7_1_WIDE_BACK:
+	case CEF_CHANNEL_LAYOUT_7_1_WIDE:
+		return SPEAKERS_7POINT1;   /**< Channels: FL, FR, FC, LFE, RL, RR, SL, SR */
+	}
+	return SPEAKERS_UNKNOWN;
+}
+
+void BrowserClient::OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
+	int audio_stream_id_,
+	const void** data,
+	int frames,
+	int64_t pts)
+{
+	struct obs_source_audio audio = {};
+
+	if (!bs) {
+		return;
+	}
+
+	if (audio_stream_id != audio_stream_id_)
+		return;
+
+	const uint8_t** pcm = (const uint8_t**)data;
+	speaker_layout speakers = getSpeakerLayout(channel_layout);
+	int speaker_count = get_audio_channels(speakers);
+	for (int i = 0; i < speaker_count; i++)
+		audio.data[i] = pcm[i];
+
+	audio.samples_per_sec = sample_rate;
+	audio.frames = frames;
+	audio.format = AUDIO_FORMAT_FLOAT_PLANAR;
+	audio.speakers = speakers;
+	audio.timestamp = (uint64_t)pts * 1000;
+
+	obs_source_output_audio(bs->source, &audio);
+}
+
+void BrowserClient::OnAudioStreamStopped(CefRefPtr<CefBrowser> browser,
+	int audio_stream_id_)
+{
+	if (!bs) {
+		return;
+	}
+	if (audio_stream_id != audio_stream_id_)
+		return;	
+}
 
 void BrowserClient::OnLoadEnd(
 		CefRefPtr<CefBrowser>,

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -31,6 +31,7 @@ class BrowserClient : public CefClient,
                       public CefLifeSpanHandler,
                       public CefContextMenuHandler,
                       public CefRenderHandler,
+                      public CefAudioHandler,
                       public CefLoadHandler {
 
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
@@ -45,6 +46,11 @@ public:
 	BrowserSource *bs;
 	CefRect popupRect;
 	CefRect originalPopupRect;
+	int audio_stream_id;
+	int sample_rate;
+	int channels;
+	ChannelLayout channel_layout;
+	int frames_per_buffer;
 
 	inline BrowserClient(BrowserSource *bs_, bool sharing_avail)
 		: bs(bs_)
@@ -61,6 +67,7 @@ public:
 	virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override;
 	virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler()
 		override;
+	virtual CefRefPtr<CefAudioHandler> GetAudioHandler() override;
 
 	virtual bool OnProcessMessageReceived(
 			CefRefPtr<CefBrowser> browser,
@@ -120,6 +127,21 @@ public:
 			void *shared_handle) override;
 #endif
 
+	virtual void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
+			int audio_stream_id,
+			const void ** data,
+			int frames,
+			int64_t pts) override;
+
+	virtual void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser,
+			int audio_stream_id);
+
+	virtual void OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
+			int audio_stream_id,
+			int channels,
+			ChannelLayout channel_layout,
+			int sample_rate,
+			int frames_per_buffer) override;
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(
 			CefRefPtr<CefBrowser> browser,

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -243,6 +243,7 @@ void RegisterBrowserSource()
 	info.id                     = "browser_source";
 	info.type                   = OBS_SOURCE_TYPE_INPUT;
 	info.output_flags           = OBS_SOURCE_VIDEO |
+				      OBS_SOURCE_AUDIO |
 	                              OBS_SOURCE_CUSTOM_DRAW |
 	                              OBS_SOURCE_INTERACTION |
 	                              OBS_SOURCE_DO_NOT_DUPLICATE;

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -126,6 +126,7 @@ bool BrowserSource::CreateBrowser()
 				url,
 				cefBrowserSettings,
 				nullptr);
+		cefBrowser->GetHost()->SetAudioMuted(true);
 	});
 }
 


### PR DESCRIPTION
Relies on two cef PR:
177 : Add ability to capture audio output to buffer via cef handler
173 : Mute audio in the browser (issue #1806)

The audio from browser source is now muted to desktop.
It can be captured and monitored.
The PR is compatible with multiple audio sources in same browser page.

Main author: Osiris.
Other authors: Andersama & pkv

Co-authored-by: Michel Snippe <michel@sokar.nl>
Co-authored-by: Andersama <anderson.john.alexander@gmail.com>
Co-authored-by: pkv <pkv.stream@gmail.com