### PR TITLE
Use fake UI for media stream

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -53,6 +53,8 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 	}
 
 	command_line->AppendSwitch("enable-system-flash");
+	
+	command_line->AppendSwitch("use-fake-ui-for-media-stream");
 
 	command_line->AppendSwitchWithValue("autoplay-policy",
 			"no-user-gesture-required");


### PR DESCRIPTION
Use fake UI for media stream avoids the need to grant camera/microphone permissions.

Fixes #146