### PR TITLE
Add replay buffer events to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ window.addEventListener('obsSceneChanged', function(evt) {
 * obsRecordingStarted
 * obsRecordingStopping
 * obsRecordingStopped
+* obsReplaybufferStarting
+* obsReplaybufferStarted
+* obsReplaybufferStopping
+* obsReplaybufferStopped
 
 ### Get the current scene
 ```

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -417,6 +417,18 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
 		DispatchJSEvent("obsRecordingStopped", "");
 		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
+		DispatchJSEvent("obsReplaybufferStarting", nullptr);
+		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED:
+		DispatchJSEvent("obsReplaybufferStarted", nullptr);
+		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING:
+		DispatchJSEvent("obsReplaybufferStopping", nullptr);
+		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED:
+		DispatchJSEvent("obsReplaybufferStopped", nullptr);
+		break;
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED: {
 		OBSSource source = obs_frontend_get_current_scene();
 		obs_source_release(source);


### PR DESCRIPTION
Goes well with the `getStatus` function which returns the replay buffer status.