### PR TITLE
Add JS events for source active/visible change

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ window.addEventListener('obsSceneChanged', function(evt) {
 });
 ```
 #### Other events that are available
+* obsSourceVisibleChanged
+* obsSourceActiveChanged
 * obsStreamingStarting
 * obsStreamingStarted
 * obsStreamingStopping

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -388,7 +388,8 @@ void RegisterBrowserSource()
 
 /* ========================================================================= */
 
-extern void DispatchJSEvent(std::string eventName, std::string jsonString);
+extern void DispatchJSEvent(std::string eventName, std::string jsonString,
+			    BrowserSource *browser = nullptr);
 
 static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 {


### PR DESCRIPTION
Partially fixes #72

Known issues:
- [x] These new events fire on all browsers, even those unrelated to the visibility change