### PR TITLE
Add audio capture for browser source

### DIFF
--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -31,6 +31,9 @@ class BrowserClient : public CefClient,
 		      public CefLifeSpanHandler,
 		      public CefContextMenuHandler,
 		      public CefRenderHandler,
+#if CHROME_VERSION_BUILD >= 3683
+		      public CefAudioHandler,
+#endif
 		      public CefLoadHandler {
 
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
@@ -45,6 +48,13 @@ public:
 	BrowserSource *bs;
 	CefRect popupRect;
 	CefRect originalPopupRect;
+#if CHROME_VERSION_BUILD >= 3683
+	int audio_stream_id;
+	int sample_rate;
+	int channels;
+	ChannelLayout channel_layout;
+	int frames_per_buffer;
+#endif
 
 	inline BrowserClient(BrowserSource *bs_, bool sharing_avail) : bs(bs_)
 	{
@@ -60,6 +70,9 @@ public:
 	virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override;
 	virtual CefRefPtr<CefContextMenuHandler>
 	GetContextMenuHandler() override;
+#if CHROME_VERSION_BUILD >= 3683
+	virtual CefRefPtr<CefAudioHandler> GetAudioHandler() override;
+#endif
 
 	virtual bool
 	OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
@@ -116,7 +129,22 @@ public:
 					const RectList &dirtyRects,
 					void *shared_handle) override;
 #endif
+#if CHROME_VERSION_BUILD >= 3683
+	virtual void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
+					 int audio_stream_id,
+					 const float **data, int frames,
+					 int64_t pts) override;
 
+	virtual void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser,
+					  int audio_stream_id);
+
+	virtual void OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
+					  int audio_stream_id, int channels,
+					  ChannelLayout channel_layout,
+					  int sample_rate,
+					  int frames_per_buffer) override;
+
+#endif
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,
 			       CefRefPtr<CefFrame> frame,

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -316,7 +316,8 @@ void RegisterBrowserSource()
 			    OBS_SOURCE_AUDIO |
 #endif
 			    OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_INTERACTION |
-			    OBS_SOURCE_DO_NOT_DUPLICATE;
+			    OBS_SOURCE_DO_NOT_DUPLICATE |
+			    OBS_SOURCE_MONITOR_BY_DEFAULT;
 	info.get_properties = browser_source_get_properties;
 	info.get_defaults = browser_source_get_defaults;
 

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -311,8 +311,11 @@ void RegisterBrowserSource()
 	struct obs_source_info info = {};
 	info.id = "browser_source";
 	info.type = OBS_SOURCE_TYPE_INPUT;
-	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			    OBS_SOURCE_INTERACTION |
+	info.output_flags = OBS_SOURCE_VIDEO |
+#if CHROME_VERSION_BUILD >= 3683
+			    OBS_SOURCE_AUDIO |
+#endif
+			    OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_INTERACTION |
 			    OBS_SOURCE_DO_NOT_DUPLICATE;
 	info.get_properties = browser_source_get_properties;
 	info.get_defaults = browser_source_get_defaults;

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -144,6 +144,9 @@ bool BrowserSource::CreateBrowser()
 			CefRefPtr<CefDictionaryValue>(),
 #endif
 			nullptr);
+#if CHROME_VERSION_BUILD >= 3683
+		cefBrowser->GetHost()->SetAudioMuted(true);
+#endif
 	});
 }
 


### PR DESCRIPTION
Relies on two cef commits (both on branch 3683):
58e1149 : Add ability to capture audio output to buffer via cef handler
1501768 : Mute audio in the browser (issue #1806)

This PR turns a browser source into a regular audio source, with a vue-meter on the Sound Mixer.

The audio from browser source is now muted to desktop.
It can be captured and monitored.
The PR is compatible with multiple audio sources in same browser page.

Main author: Osiris.
Other authors: Andersama & pkv

**In memoriam. Osiris**
Thanks for all that you did for this project. We deeply miss the
opportunity to keep working with you. - andersama , pkv & WizardCM

Co-authored-by: Michel Snippe <michel@sokar.nl>
Co-authored-by: Andersama <anderson.john.alexander@gmail.com>
Co-authored-by: pkv <pkv.stream@gmail.com>
Co-authored-by: WizardCM <git@wizardcm.com>