### PR TITLE
Fix AddCustomScheme function for cef >= 3683

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -45,7 +45,11 @@ CefRefPtr<CefBrowserProcessHandler> BrowserApp::GetBrowserProcessHandler()
 
 void BrowserApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 {
-#if CHROME_VERSION_BUILD >= 3029
+#if CHROME_VERSION_BUILD >= 3683
+	registrar->AddCustomScheme("http",
+				   CEF_SCHEME_OPTION_STANDARD |
+					   CEF_SCHEME_OPTION_CORS_ENABLED);
+#elif CHROME_VERSION_BUILD >= 3029
 	registrar->AddCustomScheme("http", true, false, false, false, true,
 				   false);
 #else


### PR DESCRIPTION
Since cef 3683 AddCustomScheme has  only two args instead of 6 and uses a bitmask arg.
This fixes the function for cef >= 3683.