### PR TITLE
Fix error when using CEF >= 3683

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -39,7 +39,9 @@ CefRefPtr<CefBrowserProcessHandler> BrowserApp::GetBrowserProcessHandler()
 void BrowserApp::OnRegisterCustomSchemes(
 		CefRawPtr<CefSchemeRegistrar> registrar)
 {
-#if CHROME_VERSION_BUILD >= 3029
+#if CHROME_VERSION_BUILD >= 3683
+	registrar->AddCustomScheme("http", CEF_SCHEME_OPTION_STANDARD);
+#elif CHROME_VERSION_BUILD >= 3029
 	registrar->AddCustomScheme("http", true, false, false, false, true,
 			false);
 #else


### PR DESCRIPTION
CEF 3683 broke api by changing the parameters of
AddCustomScheme function.