### PR TITLE
Panels: Right click Reload, use Qt context menu

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -30,6 +30,11 @@ CefRefPtr<CefLifeSpanHandler> QCefBrowserClient::GetLifeSpanHandler()
 	return this;
 }
 
+CefRefPtr<CefContextMenuHandler> QCefBrowserClient::GetContextMenuHandler()
+{
+	return this;
+}
+
 CefRefPtr<CefKeyboardHandler> QCefBrowserClient::GetKeyboardHandler()
 {
 	return this;
@@ -184,6 +189,21 @@ bool QCefBrowserClient::OnBeforePopup(
 	QUrl url = QUrl(str_url.c_str(), QUrl::TolerantMode);
 	QDesktopServices::openUrl(url);
 	return true;
+}
+
+void QCefBrowserClient::OnBeforeContextMenu(CefRefPtr<CefBrowser>,
+					    CefRefPtr<CefFrame>,
+					    CefRefPtr<CefContextMenuParams>,
+					    CefRefPtr<CefMenuModel> model)
+{
+	if (model->IsVisible(MENU_ID_BACK) &&
+	    (!model->IsVisible(MENU_ID_RELOAD) &&
+	     !model->IsVisible(MENU_ID_RELOAD_NOCACHE))) {
+		model->InsertItemAt(2, MENU_ID_RELOAD_NOCACHE, "&Reload");
+	}
+	if (model->IsVisible(MENU_ID_PRINT)) {
+		model->Remove(MENU_ID_PRINT);
+	}
 }
 
 void QCefBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>,

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -9,6 +9,7 @@ class QCefBrowserClient : public CefClient,
 			  public CefDisplayHandler,
 			  public CefRequestHandler,
 			  public CefLifeSpanHandler,
+			  public CefContextMenuHandler,
 			  public CefLoadHandler,
 			  public CefKeyboardHandler {
 
@@ -28,6 +29,8 @@ public:
 	virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override;
 	virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override;
 	virtual CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() override;
+	virtual CefRefPtr<CefContextMenuHandler>
+	GetContextMenuHandler() override;
 
 	/* CefDisplayHandler */
 	virtual void OnTitleChange(CefRefPtr<CefBrowser> browser,
@@ -64,6 +67,13 @@ public:
 		CefRefPtr<CefDictionaryValue> &extra_info,
 #endif
 		bool *no_javascript_access) override;
+
+	/* CefContextMenuHandler */
+	virtual void
+	OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
+			    CefRefPtr<CefFrame> frame,
+			    CefRefPtr<CefContextMenuParams> params,
+			    CefRefPtr<CefMenuModel> model) override;
 
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -75,6 +75,12 @@ public:
 			    CefRefPtr<CefContextMenuParams> params,
 			    CefRefPtr<CefMenuModel> model) override;
 
+	virtual bool
+	RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+		       CefRefPtr<CefContextMenuParams> params,
+		       CefRefPtr<CefMenuModel> model,
+		       CefRefPtr<CefRunContextMenuCallback> callback) override;
+
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,
 			       CefRefPtr<CefFrame> frame,


### PR DESCRIPTION
### Description

This PR introduces two core changes, split into their own two commits **(Gif examples at the end)**.

1. It allows for the modification of the contents of the CEF context menu. This is a native capability, and I've used it to perform two minor changes: the first is to enable a Reload option, to refresh the page. The second is to hide the Print option, as it's not needed. I considered also hiding "View page source". Feedback here would be good. This change overall is quite small, and can be used down the line to add/remove any options, whether they're native ones (like the Reload one) or completely custom functions.

2. Next I added a function to replace the native CEF context menu with a Qt menu. This is also a native capability, and ensures that not only the context menu is consistent with others, but also matches the OBS theme.

The second change went through a few iterations, but in the end I settled on this.

### Motivation and Context

The primary motivation is consistency. The context menu for browser docks doesn't currently follow the same design rules as all other context menus in OBS, making it feel out of place and "tacked on". It also behaves unexpectedly when the user presses the context menu key on the keyboard, where it opens two menus where one cannot be closed.
The second motivation is extensibility. By using native CEF functions to modify the dropdown, it opens the doors to further options in the future: like a "Dock Configuration" button, for example. In this case, it starts off simple by adding a much-requested Reload option.

Implementation details:

* `RunContextMenu` requires a "return true" if you're rendering your own context menu (which, we are). The callback can be run synchronously or asynchronously, and has no time limit
* CEF Docs state: "Do not keep references to `params` or `model` outside of this callback." therefore I had to create a new object to store the basics of the contents of the dropdown. The `model` gives us everything we need - the `text`, `command id`, `enabled` status, and menu item `type`.
* Qt doesn't allow you to create widgets outside of the UI thread, so once the menu items are acquired from the `model`, we create a `QMenu` in the UI thread, and populate it with the items, creating separators as needed.
* The use of `exec()` was chosen as it's used in other places in OBS, and because it allowed for the smallest bit of code: it synchronously returns whether an action was clicked or not, allowing the ability to then run the necessary CEF callback. **If you don't run the Cancel() callback if an item hasn't been chosen, then you can't open the dropdown a second time.** The event just never triggers.

### How Has This Been Tested?

Add a custom browser dock, or enable service integration, and right click anywhere within the webpage. Depending on whether text is selected, and what element you right click on, CEF will give you different options in the context menu. Example: right click a random area where there's no text, and then right click a text input field (the latter will unlock Copy/Paste).

**Before:**
![2019-05-18_21-29-19](https://user-images.githubusercontent.com/941350/57968901-28608880-79b4-11e9-980d-1cbf67f48434.gif)

**After:**
![2019-05-18_21-34-36](https://user-images.githubusercontent.com/941350/57968965-c3596280-79b4-11e9-8234-c0f6df0473b3.gif)

### Types of changes
 - New feature (non-breaking change which adds functionality)
 - Bug fix (non-breaking change which fixes an issue)
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
