### PR TITLE
Linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,11 @@ if (WIN32)
 	set_target_properties(obs-browser-page PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 endif(WIN32)
 
+if (UNIX AND NOT APPLE)
+    set_target_properties(obs-browser PROPERTIES INSTALL_RPATH "$ORIGIN/")
+    set_target_properties(obs-browser-page PROPERTIES INSTALL_RPATH "$ORIGIN/")
+endif()
+
 # ----------------------------------------------------------------------------
 
 if (WIN32)
@@ -204,6 +209,11 @@ if (WIN32)
 		"${CEF_ROOT_DIR}/Release/v8_context_snapshot.bin"
 		"${CMAKE_BINARY_DIR}/rundir/$<CONFIGURATION>/obs-plugins/${BITS}bit/"
 	)
+endif()
+
+if (UNIX AND NOT APPLE)
+	install(DIRECTORY "${CEF_ROOT_DIR}/Resources/" DESTINATION "${OBS_PLUGIN_DESTINATION}")
+	install(DIRECTORY "${CEF_ROOT_DIR}/Release/" DESTINATION "${OBS_PLUGIN_DESTINATION}")
 endif()
 
 if(APPLE AND NOT BROWSER_DEPLOY)

--- a/FindCEF.cmake
+++ b/FindCEF.cmake
@@ -19,6 +19,16 @@ if(APPLE)
 			${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release
 			${CEF_ROOT_DIR}/build/libcef_dll
 			${CEF_ROOT_DIR}/build/libcef_dll_wrapper)
+elseif(UNIX)
+	find_library(CEF_LIBRARY
+		NAMES libcef.so "Chromium Embedded Framework"
+		NO_DEFAULT_PATH
+		PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Release)
+	find_library(CEFWRAPPER_LIBRARY
+		NAMES libcef_dll_wrapper.a
+		NO_DEFAULT_PATH
+		PATHS ${CEF_ROOT_DIR}/build/libcef_dll_wrapper
+			${CEF_ROOT_DIR}/libcef_dll_wrapper)
 else()
 	find_library(CEF_LIBRARY
 		NAMES cef libcef cef.lib libcef.o "Chromium Embedded Framework"


### PR DESCRIPTION
Inspired by #159 
Closes https://github.com/obsproject/obs-browser/issues/141
Add FindCEF and install instructions for Linux.

Works on Linux when built with CEF version 3683 and obs-studio launched with QT_NO_GLIB=1.