### PR TITLE
obs-browser: simulate page visibility API

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -87,7 +87,8 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 					    "no-user-gesture-required");
 }
 
-void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
+void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
+				  CefRefPtr<CefFrame>,
 				  CefRefPtr<CefV8Context> context)
 {
 	CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
@@ -110,6 +111,10 @@ void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 		CefV8Value::CreateFunction("getStatus", this);
 	obsStudioObj->SetValue("getStatus", getStatus,
 			       V8_PROPERTY_ATTRIBUTE_NONE);
+
+#if !ENABLE_WASHIDDEN
+	SetDocumentVisibility(browser, pendingDocumentVisibilityState);
+#endif
 }
 
 void BrowserApp::ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
@@ -131,6 +136,91 @@ void BrowserApp::ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
 	context->Exit();
 }
 
+#if !ENABLE_WASHIDDEN
+void BrowserApp::SetFrameDocumentVisibility(CefRefPtr<CefBrowser> browser,
+					    CefRefPtr<CefFrame> frame,
+					    bool isVisible)
+{
+	CefRefPtr<CefV8Context> context = frame->GetV8Context();
+
+	context->Enter();
+
+	CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
+
+	CefRefPtr<CefV8Value> documentObject = globalObj->GetValue("document");
+
+	if (!!documentObject) {
+		documentObject->SetValue("hidden",
+					 CefV8Value::CreateBool(!isVisible),
+					 V8_PROPERTY_ATTRIBUTE_READONLY);
+
+		documentObject->SetValue(
+			"visibilityState",
+			CefV8Value::CreateString(isVisible ? "visible"
+							   : "hidden"),
+			V8_PROPERTY_ATTRIBUTE_READONLY);
+
+		std::string script = "new CustomEvent('visibilitychange', {});";
+
+		CefRefPtr<CefV8Value> returnValue;
+		CefRefPtr<CefV8Exception> exception;
+
+		/* Create the CustomEvent object
+		 * We have to use eval to invoke the new operator */
+		bool success = context->Eval(script, frame->GetURL(), 0,
+					     returnValue, exception);
+
+		if (success) {
+			CefV8ValueList arguments;
+			arguments.push_back(returnValue);
+
+			CefRefPtr<CefV8Value> dispatchEvent =
+				documentObject->GetValue("dispatchEvent");
+
+			/* Dispatch visibilitychange event on the document
+			 * object */
+			dispatchEvent->ExecuteFunction(documentObject,
+						       arguments);
+		}
+	}
+
+	context->Exit();
+}
+
+void BrowserApp::SetDocumentVisibility(CefRefPtr<CefBrowser> browser,
+				       bool isVisible)
+{
+	/* This method might be called before OnContextCreated
+	 * call is made. We'll save the requested visibility
+	 * state here, and use it later in OnContextCreated to
+	 * set initial page visibility state. */
+	pendingDocumentVisibilityState = isVisible;
+
+	std::vector<int64> frameIdentifiers;
+
+	/* Set visibility state for every frame in the browser
+	 *
+	 * According to the Page Visibility API documentation:
+	 * https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+	 *
+	 * "Visibility states of an <iframe> are the same as
+	 * the parent document. Hiding an <iframe> using CSS
+	 * properties (such as display: none;) doesn't trigger
+	 * visibility events or change the state of the document
+	 * contained within the frame."
+	 *
+	 * Thus, we set the same visibility state for every frame of the browser.
+	 */
+	browser->GetFrameIdentifiers(frameIdentifiers);
+
+	for (int64 frameId : frameIdentifiers) {
+		CefRefPtr<CefFrame> frame = browser->GetFrame(frameId);
+
+		SetFrameDocumentVisibility(browser, frame, isVisible);
+	}
+}
+#endif
+
 bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 #if CHROME_VERSION_BUILD >= 3770
 					  CefRefPtr<CefFrame> frame,
@@ -147,6 +237,10 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 		arguments.push_back(CefV8Value::CreateBool(args->GetBool(0)));
 
 		ExecuteJSFunction(browser, "onVisibilityChange", arguments);
+
+#if !ENABLE_WASHIDDEN
+		SetDocumentVisibility(browser, args->GetBool(0));
+#endif
 
 	} else if (message->GetName() == "Active") {
 		CefV8ValueList arguments;

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -115,5 +115,15 @@ public:
 	QTimer frameTimer;
 #endif
 
+#if !ENABLE_WASHIDDEN
+	bool pendingDocumentVisibilityState = false;
+
+	void SetFrameDocumentVisibility(CefRefPtr<CefBrowser> browser,
+					CefRefPtr<CefFrame> frame,
+					bool isVisible);
+	void SetDocumentVisibility(CefRefPtr<CefBrowser> browser,
+				   bool isVisible);
+#endif
+
 	IMPLEMENT_REFCOUNTING(BrowserApp);
 };

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -73,6 +73,7 @@ struct BrowserSource {
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
 	bool reset_frame = false;
 #endif
+	bool is_showing = false;
 
 	inline void DestroyTextures()
 	{


### PR DESCRIPTION
### Description, Motivation and Context

WasHidden() CEF API was abandoned on CEF 3507+ by commit b7d3ac2 due to
a bug with OSR in Chromium. This defeated the standard Page Visibility
API which webpages rely upon to conserve resources when browser sources
are invisible.

We simulate the Page Visibility API by updating the relevant document
properties (document.hidden & document.visibilityState) and firing
the 'visibilitychange' event when browser source visibility state
updates.

We also address initial visible/hidden state by storing the state
reported to SetShowing() and reporting initial state immediately after
creating the browser (initial SetShowing call is made before browser is
created due to the async nature of this process).

### How Has This Been Tested?
Page Visibility API was tested with local HTML/JS pages. Tested both changes to page visibility and initial state.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
