### PR TITLE
Suppress dup page visibility events on CEF 3440

### DIFF
--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -37,6 +37,12 @@
 #include <include/cef_render_process_handler.h>
 #include <include/cef_request_context_handler.h>
 
+#if CHROME_VERSION_BUILD < 3507
+#define ENABLE_WASHIDDEN 1
+#else
+#define ENABLE_WASHIDDEN 0
+#endif
+
 #if CHROME_VERSION_BUILD >= 3770
 #define SendBrowserProcessMessage(browser, pid, msg) \
 	browser->GetMainFrame()->SendProcessMessage(pid, msg);

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -35,12 +35,6 @@
 extern bool hwaccel;
 #endif
 
-#if CHROME_VERSION_BUILD < 3507
-#define ENABLE_WASHIDDEN 1
-#else
-#define ENABLE_WASHIDDEN 0
-#endif
-
 struct AudioStream {
 	OBSSource source;
 	speaker_layout speakers;


### PR DESCRIPTION
### Description, Motivation and Context
browser-app.cpp code relies on ENABLE_WASHIDDEN macro being set to 1 or
0 in `obs-browser-source.hpp`.

If ENABLE_WASHIDDEN macro is not defined, page visibility API
simulation code kicks in, in addition to normal page visibility
mutations triggered by WasHidden() for CEF versions
older than 3507.

We move ENABLE_WASHIDDEN macro into `cef-headers.hpp` which is included
by both `obs-browser-source.cpp` and `browser-app.cpp`

### How Has This Been Tested?
Tested page visibility API with CEF 3440 and CEF 3770.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
