### PR TITLE
Map absolute to file URLs

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -22,6 +22,7 @@
 #include "wide-string.hpp"
 #include <util/threading.h>
 #include <QApplication>
+#include <util/dstr.h>
 #include <functional>
 #include <thread>
 #include <mutex>
@@ -420,6 +421,15 @@ void BrowserSource::Update(obs_data_t *settings)
 			n_url = "file://" + n_url;
 #endif
 		}
+
+#if ENABLE_LOCAL_FILE_URL_SCHEME
+		if (astrcmpi_n(n_url.c_str(), "http://absolute/", 16) == 0) {
+			/* Replace http://absolute/ URLs with file://
+			 * URLs if file:// URLs are enabled */
+			n_url = "file:///" + n_url.substr(16);
+			n_is_local = true;
+		}
+#endif
 
 		if (n_is_local == is_local && n_width == width &&
 		    n_height == height && n_fps_custom == fps_custom &&


### PR DESCRIPTION
### Description, Motivation and Context
file:// URLs have replaced http://absolute/ URLs when building with
newer CEF versions, due to a bug in Chromium media player which causes
large media files not to load when accessed via the http://absolute/
URL scheme handler.

Nevertheless, some users still have explicit references to local files
accessed via the http://absolute/ URL handler.

To make sure those users have smooth upgrade, we replace
http://absolute/ with file:/// behind the scenes, to keep the files
accessible.

### How Has This Been Tested?
Tested an http://absolute/ URL referencing a local HTML file which in turn references a large WEBM file.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
