### PR TITLE
Disable access to media keys

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -83,6 +83,18 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 
 	command_line->AppendSwitch("enable-system-flash");
 
+	if (command_line->HasSwitch("disable-features")) {
+		// Don't override existing, as this can break OSR
+		std::string disableFeatures =
+			command_line->GetSwitchValue("disable-features");
+		disableFeatures += ",HardwareMediaKeyHandling";
+		command_line->AppendSwitchWithValue("disable-features",
+						    disableFeatures);
+	} else {
+		command_line->AppendSwitchWithValue("disable-features",
+						    "HardwareMediaKeyHandling");
+	}
+
 	command_line->AppendSwitchWithValue("autoplay-policy",
 					    "no-user-gesture-required");
 }


### PR DESCRIPTION
### Description
Stops hardware media keys from pausing/resuming playback in browser sources. This is regardless of the "Control audio using OBS" option.

### Motivation and Context
Recent versions of Chromium (including Google Chrome, and apparently CEF) allow you to control media playback on a page using hardware Play/Pause buttons. This PR disables the capability using the only launch parameter I could find.

As the parameter is already in use as part of OSR (I think), rather than replacing it (which caused the browser source to remain invisible), if the parameter is already detected, the code will append the disabled entry.

### How Has This Been Tested?
* Launch OBS Studio without this code.
* Add a browser source with a YouTube URL
* Notice that in Windows 10's media UI (when you change volume), obs64.exe appears
* Press either the Pause button in the media overlay, or on the hardware buttons on your keyboard. Notice that the media stops playing, and resumes when you click again.

Then:
* Apply this PR
* Notice obs64,exe no longer appears when it's playing browser media, and that pressing the hardware media controls no longer pauses the playback.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
