### PR TITLE
obs-browser: Replace register with __restrict

### DIFF
--- a/obs-browser-source-audio.cpp
+++ b/obs-browser-source-audio.cpp
@@ -25,15 +25,16 @@ void BrowserSource::EnumAudioStreams(obs_source_enum_proc_t cb, void *param)
 	}
 }
 
-static inline void mix_audio(float *p_out, float *p_in, size_t pos,
+static inline void mix_audio(float *__restrict p_out,
+			     const float *__restrict p_in, size_t pos,
 			     size_t count)
 {
-	register float *out = p_out;
-	register float *in = p_in + pos;
-	register float *end = in + count;
+	float *__restrict out = p_out;
+	const float *__restrict in = p_in + pos;
+	const float *__restrict end = in + count;
 
 	while (in < end)
-		*(out++) += *(in++);
+		*out++ += *in++;
 }
 
 bool BrowserSource::AudioMix(uint64_t *ts_out,


### PR DESCRIPTION
### Description
Replace register with __restrict since register is not supported in C++17.

### Motivation and Context
Trying to enable C++17 as a byproduct of wanting to support WinRT headers.

### How Has This Been Tested?
Breakpoint inspection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.