### PR TITLE
Use OBS canvas size as browser source default size

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -110,10 +110,15 @@ overflow: hidden; \
 
 static void browser_source_get_defaults(obs_data_t *settings)
 {
+	struct obs_video_info ovi = {0};
+	obs_get_video_info(&ovi);
+	int width = ovi.base_width ? ovi.base_width : 800;
+	int height = ovi.base_height ? ovi.base_height : 600;
+
 	obs_data_set_default_string(settings, "url",
 				    "https://obsproject.com/browser-source");
-	obs_data_set_default_int(settings, "width", 800);
-	obs_data_set_default_int(settings, "height", 600);
+	obs_data_set_default_int(settings, "width", width);
+	obs_data_set_default_int(settings, "height", height);
 	obs_data_set_default_int(settings, "fps", 30);
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
 	obs_data_set_default_bool(settings, "fps_custom", false);


### PR DESCRIPTION
### Description
This is a minor QoL change to make browser sources default to be the same size as the user's OBS canvas. For users using overlays, this should reduce the work required to add a browser source for an overlay. For all other use cases, this should not create extra work.

If the canvas width and height are not defined (I don't know why this would happen), the width and height should fallback to 800x600. Feedback on this particular section of code would be appreciated.

**This PR depends on https://github.com/obsproject/obs-studio/pull/2073/ to maintain backwards compatibility with previously created browser sources that did not have a width and height different from the default specified.**

![image](https://user-images.githubusercontent.com/624931/66537288-e31d2e80-eaed-11e9-8440-9b42cd7748a0.png)

### Motivation and Context
At TwitchCon, some users expressed that having browser sources default to the same size as the OBS canvas would save them time/work for setting up scenes using browser source based overlays.

### How Has This Been Tested?
I compiled and tested this on Windows 10 Home 1903 (Build 18362.388) 64-bit.
1. Open OBS.
2. Add a new browser source.

Before this change, a new browser source defaults to width 800 and height 600.
After this change, a new browser source defaults to the width and height of the OBS canvas.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
