### PR TITLE
Remove unused code

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -131,9 +131,6 @@ bool BrowserSource::CreateBrowser()
 		bool hwaccel = false;
 #endif
 
-		struct obs_video_info ovi;
-		obs_get_video_info(&ovi);
-
 		CefRefPtr<BrowserClient> browserClient = new BrowserClient(
 			this, hwaccel && tex_sharing_avail, reroute_audio);
 


### PR DESCRIPTION
### Description
This change removes some unused code that was [introduced in the 2.0 rewrite](https://github.com/obsproject/obs-browser/blob/46116403705b482eeccd0c2d1d2136c8a610747f/obs-browser-source.cpp#L88).  As far as I can tell, the code is never used or referenced.  I could not tell if this gets passed to CEF via `QueueCEFTask`, so hopefully someone (probably Jim) can confirm that this code is really unused.

### Motivation and Context
Keeping the code clean.

### How Has This Been Tested?
I compiled and tested this on Windows 10 Home 1903 (Build 18362.388) 64-bit with VS2017.  I ran OBS and created a new browser source, saved it, closed OBS, and reopened OBS.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
