### PR TITLE
Remove ExecuteOnBrowser wrapper on destroy

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -185,27 +185,24 @@ bool BrowserSource::CreateBrowser()
 	});
 }
 
-void BrowserSource::DestroyBrowser(bool async)
+void BrowserSource::DestroyBrowser()
 {
-	ExecuteOnBrowser(
-		[](CefRefPtr<CefBrowser> cefBrowser) {
-			CefRefPtr<CefClient> client =
-				cefBrowser->GetHost()->GetClient();
-			BrowserClient *bc =
-				reinterpret_cast<BrowserClient *>(client.get());
-			if (bc) {
-				bc->bs = nullptr;
-			}
+	if (!cefBrowser)
+		return;
 
-			/*
-		 * This stops rendering
-		 * http://magpcss.org/ceforum/viewtopic.php?f=6&t=12079
-		 * https://bitbucket.org/chromiumembedded/cef/issues/1363/washidden-api-got-broken-on-branch-2062)
-		 */
-			cefBrowser->GetHost()->WasHidden(true);
-			cefBrowser->GetHost()->CloseBrowser(true);
-		},
-		async);
+	CefRefPtr<CefClient> client = cefBrowser->GetHost()->GetClient();
+	BrowserClient *bc = reinterpret_cast<BrowserClient *>(client.get());
+	if (bc) {
+		bc->bs = nullptr;
+	}
+
+	/*
+	 * This stops rendering
+	 * http://magpcss.org/ceforum/viewtopic.php?f=6&t=12079
+	 * https://bitbucket.org/chromiumembedded/cef/issues/1363/washidden-api-got-broken-on-branch-2062)
+	 */
+	cefBrowser->GetHost()->WasHidden(true);
+	cefBrowser->GetHost()->CloseBrowser(true);
 
 	cefBrowser = nullptr;
 }
@@ -330,7 +327,7 @@ void BrowserSource::SetShowing(bool showing)
 		if (showing) {
 			Update();
 		} else {
-			DestroyBrowser(true);
+			DestroyBrowser();
 		}
 	} else {
 #if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
@@ -453,7 +450,7 @@ void BrowserSource::Update(obs_data_t *settings)
 		obs_source_set_audio_active(source, reroute_audio);
 	}
 
-	DestroyBrowser(true);
+	DestroyBrowser();
 	DestroyTextures();
 	ClearAudioStreams();
 	if (!shutdown_on_invisible || obs_source_showing(source))

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -82,7 +82,7 @@ struct BrowserSource {
 	/* ---------------------------- */
 
 	bool CreateBrowser();
-	void DestroyBrowser(bool async = false);
+	void DestroyBrowser();
 	void ClearAudioStreams();
 	void ExecuteOnBrowser(BrowserFunc func, bool async = false);
 


### PR DESCRIPTION
### Description
Remove `ExecuteOnBrowser()` wrapper from `BrowserSource::DestroyBrowser()`.

### Motivation and Context
Under certain conditions, when browser source scene items are removed
in a loop, CEF UI thread may hang waiting for previous invocations of
ExecuteOnBrowser() to complete resulting in a deadlock.

Since CefBrowserHost::WasHidden() and CefBrowserHost::CloseBrowser()
are not required to be called on a certain thread, removing
ExecuteOnBrowser() altogether preserves the functionality, eliminates
the deadlock and simplifies the code.

### How Has This Been Tested?
- Remove single browser source
- Remove multiple browser sources
- Change scene collection
- Hide/showbrowser source with "Shutdown when hidden" checked
- Exit program

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
