### PR TITLE
Display errors in browser panels instead of an empty page

### DIFF
--- a/data/error.html
+++ b/data/error.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<head>
+		<title>OBS | Browser Source</title>
+		
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width,initial-scale=1.0">
+		<meta name="description" content="OBS (Open Broadcaster Software) is free and open source software for video recording and live streaming. Stream to Twitch, YouTube and many other providers or record your own videos with high quality H264 / AAC encoding.">
+		<meta name="keywords" content="OBS,OBS Studio,Stream,Video,Live Streaming,Recording,Games,Twitch,YouTube,Livestream,Open Broadcaster Software">
+		
+		<meta name="obs-width" content="800">
+		<meta name="obs-height" content="600">
+		<meta name="obs-fps" content="60">
+		<meta name="obs-shutdown" content="true">
+		<meta name="obs-refresh" content="false">
+
+		<meta name="obs-browser" content="width=800,height=600,fps=60,shutdown=true,refresh=false">
+
+
+		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+		<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+		
+		<style>
+			/* Style reset */
+			/* http://meyerweb.com/eric/tools/css/reset/ 
+				v2.0 | 20110126
+				License: none (public domain)
+			*/
+		
+			html, body, div, span, applet, object, iframe,
+			h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+			a, abbr, acronym, address, big, cite, code,
+			del, dfn, em, img, ins, kbd, q, s, samp,
+			small, strike, strong, sub, sup, tt, var,
+			b, u, i, center,
+			dl, dt, dd, ol, ul, li,
+			fieldset, form, label, legend,
+			table, caption, tbody, tfoot, thead, tr, th, td,
+			article, aside, canvas, details, embed, 
+			figure, figcaption, footer, header, hgroup, 
+			menu, nav, output, ruby, section, summary,
+			time, mark, audio, video {
+				margin: 0;
+				padding: 0;
+				border: 0;
+				font-size: 100%;
+				font: inherit;
+				vertical-align: baseline;
+			}
+			/* HTML5 display-role reset for older browsers */
+			article, aside, details, figcaption, figure, 
+			footer, header, hgroup, menu, nav, section {
+				display: block;
+			}
+			body {
+				line-height: 1;
+			}
+			ol, ul {
+				list-style: none;
+			}
+			blockquote, q {
+				quotes: none;
+			}
+			blockquote:before, blockquote:after,
+			q:before, q:after {
+				content: '';
+				content: none;
+			}
+			table {
+				border-collapse: collapse;
+				border-spacing: 0;
+			}
+			/* End of style reset */
+		
+			body {
+				font-family: "Open Sans", sans-serif;
+				color: white;
+			}
+			
+			p + h1, p + h2, p + h3, p + h4, p + h5 {
+				margin-top: 32px;
+			}
+		
+			p + p {
+				margin-top: 24px;
+			}
+			
+			.main_slant {
+				position: absolute;
+				width: 200%;
+				left: -50%;
+			}
+			
+			#bg_slant1 {
+				left: -80%;
+				bottom: -20%;
+				height: 75%;
+				width: 250%;
+				background: #202d6f;
+				transform: rotate(15deg);
+			}
+		
+			#bg_slant2 {
+				height: 200px;
+				background: #1c2b71;
+				transform: rotate(1deg);
+				top: -50px;
+			}
+		
+			#bg_slant3 {
+				height: 500px;
+				background: #0C1633;
+				transform: rotate(-8deg);
+				bottom: -200px;
+			}
+			
+			.bs-page {
+				background: #162458;
+				font-size: 14px;
+				position: relative;
+				line-height: 30px;
+				text-align: center;
+				padding: 2%;
+				width: 100vw;
+				height: 100vh;
+				box-sizing: border-box;
+				overflow: hidden;
+			}
+			
+			.bs-container {
+				position: relative;
+				max-width: 800px;
+				margin: 0px auto;
+			}
+			
+			.bs-image,
+			#Layer_1 {
+				display: block;
+				width: 80px;
+				margin: 20px auto 30px;
+			}
+			.bold {
+				font-weight: bold;
+			}
+			#retry-link {
+				color: lightgrey;
+			}
+			#retry-link:hover {
+				color: white;
+			}
+		</style>
+		
+	</head>
+	
+	<body>
+
+		<div id="wrapper">
+
+			<div class="bs-page">
+
+				<div id="bg_slant1" class="main_slant"></div>
+				<div id="bg_slant2" class="main_slant"></div>
+				<div id="bg_slant3" class="main_slant"></div>
+				
+				<div class="bs-container">
+				
+					<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 993 993"><defs><style>.cls-1{fill:url(#radial-gradient);}.cls-2{fill:none;}.cls-3{fill:url(#radial-gradient-2);}.cls-4{fill:url(#radial-gradient-3);}.cls-5{clip-path:url(#clip-path);}.cls-6{fill:url(#radial-gradient-5);}.cls-7{clip-path:url(#clip-path-2);}.cls-8{fill:url(#radial-gradient-6);}.cls-9{fill:url(#radial-gradient-7);}</style><radialGradient id="radial-gradient" cx="512.06144" cy="512.12118" r="444.12235" gradientUnits="userSpaceOnUse"><stop offset="0.99" stop-opacity="0.5"/><stop offset="1" stop-opacity="0"/></radialGradient><radialGradient id="radial-gradient-2" cx="514.5" cy="516.5" r="496.5" gradientUnits="userSpaceOnUse"><stop offset="0.91341"/><stop offset="1" stop-opacity="0"/></radialGradient><radialGradient id="radial-gradient-3" cx="512.05911" cy="512.1212" r="486.27268" gradientUnits="userSpaceOnUse"><stop offset="0.99" stop-color="#fff"/><stop offset="0.99505" stop-color="#fdfdfd"/><stop offset="0.99687" stop-color="#f6f6f6"/><stop offset="0.99817" stop-color="#ebebeb"/><stop offset="0.99921" stop-color="#dadada"/><stop offset="1" stop-color="#c7c7c7"/></radialGradient><clipPath id="clip-path" transform="translate(-18 -20)"><path id="SVGID" class="cls-1" d="M67.93793,512.1212c0,245.28622,198.83963,444.12116,444.12116,444.12116S956.185,757.40742,956.185,512.1212C956.185,266.83966,757.34063,68,512.05909,68S67.93793,266.83966,67.93793,512.1212"/></clipPath><radialGradient id="radial-gradient-5" cx="494.0614" cy="492.1212" r="444.12237" xlink:href="#radial-gradient"/><clipPath id="clip-path-2" transform="translate(-18 -20)"><path class="cls-2" d="M71.60309,512.1212c0,243.262,197.19869,440.456,440.456,440.456s440.46067-197.194,440.46067-440.456c0-243.25733-197.20334-440.45606-440.46067-440.45606S71.60309,268.86387,71.60309,512.1212"/></clipPath><radialGradient id="radial-gradient-6" cx="5.29522" cy="1029.31443" r="4.65333" gradientTransform="matrix(94.65428, 0, 0, -94.65428, -7.15418, 97921.13875)" gradientUnits="userSpaceOnUse"><stop offset="0"/><stop offset="1" stop-color="#322f32"/></radialGradient><radialGradient id="radial-gradient-7" cx="578.89023" cy="473.31944" r="353.94182" gradientTransform="translate(0 -45.94173) scale(1 1.09706)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#c2c0c2"/><stop offset="1" stop-color="#ebebeb"/></radialGradient></defs><title>OBS-Alt-2</title><path class="cls-3" d="M514.5,20C788.71048,20,1011,242.28952,1011,516.5S788.71048,1013,514.5,1013,18,790.71056,18,516.5,240.28946,20,514.5,20" transform="translate(-18 -20)"/><path class="cls-4" d="M512.05911,25.84852c268.56207,0,486.27268,217.71061,486.27268,486.27268S780.62118,998.39388,512.05911,998.39388,25.78643,780.68334,25.78643,512.1212,243.497,25.84852,512.05911,25.84852" transform="translate(-18 -20)"/><path id="SVGID-2" data-name="SVGID" class="cls-1" d="M67.93793,512.1212c0,245.28622,198.83963,444.12116,444.12116,444.12116S956.185,757.40742,956.185,512.1212C956.185,266.83966,757.34063,68,512.05909,68S67.93793,266.83966,67.93793,512.1212" transform="translate(-18 -20)"/><g class="cls-5"><rect class="cls-6" x="49.93786" y="48" width="888.24709" height="888.2424"/></g><g class="cls-7"><rect class="cls-8" x="53.60302" y="51.66514" width="880.91676" height="880.91211"/></g><path class="cls-9" d="M684.907,370.50177a199.24212,199.24212,0,0,1-277.2406,70.45605A202.74787,202.74787,0,0,1,362.753,403.18446a198.9214,198.9214,0,0,1-49.89819-141.13313c.28387-5.78965.76859-11.56257,1.52683-17.30975.74726-5.66395,1.7459-11.30258,2.97756-16.87354q1.89659-8.57846,4.54716-16.96232,2.572-8.15982,5.86352-16.07336c2.27456-5.48511,4.8105-10.85411,7.54648-16.122,2.88124-5.54761,6.07307-10.94466,9.4812-16.1843q4.7149-7.24866,10.04419-14.06235c3.85433-4.95083,7.95005-9.72719,12.27081-14.27641q6.54174-6.88764,13.66916-13.16194c4.83847-4.26274,9.91241-8.2498,15.13962-12.02191q4.04222-2.917,8.23639-5.61188a244.394,244.394,0,0,0-109.08168,323.486q.82056,1.704,1.66751,3.39519.38468.7681.77476,1.53348a4.60036,4.60036,0,0,0,.46987.91713c.32364.35883.40473.29867.89987.28969,2.578-.04676,5.15806-.03471,7.73585.021q7.14438.15426,14.26584.8147A199.577,199.577,0,0,1,499.05209,600.21532a201.32943,201.32943,0,0,1,.64133,60.16627A198.7484,198.7484,0,0,1,453.532,762.237a202.19273,202.19273,0,0,1-49.77669,41.78411A199.86222,199.86222,0,0,1,279.6049,830.51543a203.06671,203.06671,0,0,1-23.20252-4.02994c-4.95445-1.16337-9.85994-2.531-14.71085-4.07118a242.60378,242.60378,0,0,0,68.54706,18.97282,247.03638,247.03638,0,0,0,66.4102-.79809,243.52975,243.52975,0,0,0,108.66832-44.88732,246.04226,246.04226,0,0,0,59.73343-63.07421q1.04115-1.58711,2.05761-3.19021c.263-.41478.85074-1.06891.77441-1.50894a8.49447,8.49447,0,0,0-1.05057-1.9447q-2.00279-3.75737-3.8436-7.59815-3.698-7.71623-6.7219-15.73206a198.01918,198.01918,0,0,1-9.34078-33.367,200.87418,200.87418,0,0,1,.041-73.98045A197.88137,197.88137,0,0,1,548.324,536.05063,199.08091,199.08091,0,0,1,721.41371,432.9917q7.33682-.05093,14.66347.42449,7.066.47,14.088,1.41786,6.952.95079,13.82736,2.39389,6.73038,1.4208,13.355,3.29017,6.48924,1.84088,12.8432,4.11821,6.44067,2.31259,12.7085,5.06391,6.3891,2.79015,12.56139,6.04592,6.16559,3.24277,12.09984,6.9069c3.71356,2.2975,7.36439,4.705,10.91293,7.25121q5.48994,3.93921,10.72616,8.20808c3.603,2.93077,7.0801,6.01877,10.46193,9.202q5.40071,5.08362,10.4077,10.563,4.9978,5.44733,9.57009,11.27034c3.4,4.31833,6.6383,8.77214,9.66035,13.36317,3.10448,4.71627,6.03931,9.55546,8.74828,14.51488a200.21456,200.21456,0,0,1,10.06824,21.36634,206.9737,206.9737,0,0,1,7.97272,24.37127,243.74067,243.74067,0,0,0-51.67776-120.94126,245.663,245.663,0,0,0-75.01182-62.48165,242.85789,242.85789,0,0,0-95.94806-28.3044Q689.18423,370.69463,684.907,370.50177Z" transform="translate(-18 -20)"/></svg>
+					
+					<p>Error.Title</p>
+					<p>Error.Description</p>
+					<p><span id="error-string">%%ERROR_CODE%%</span><br />
+					<span class="bold">URL</span>: <span id="error-url">%%ERROR_URL%%</span></p>
+					<p><a href="%%ERROR_URL%%" id="retry-link">Error.Retry</a>
+				</div>
+			</div>
+		</div>
+
+	</body>
+</html>

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -11,3 +11,20 @@ RestartCEF="Restart CEF"
 BrowserSource="Browser"
 CustomFrameRate="Use custom frame rate"
 RerouteAudio="Control audio via OBS"
+
+Error.Title="Couldn't load that page!"
+Error.Description="Make sure the address is correct, and that the site isn't having issues."
+Error.Retry="Click here to retry"
+Error.Code="Error: %1"
+Error.URL="URL: %2"
+
+# Error codes in CEF are fetched direct from Chromium
+# CEF Reference: https://bitbucket.org/chromiumembedded/cef/src/master/include/base/internal/cef_net_error_list.h
+# Chromium Reference: https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h#
+# Cleaned up list of codes: http://txt.wzd.li/2019-12-28_12-24-39.txt
+ErrorCode.ERR_CONNECTION_REFUSED="Server refused the connection"
+ErrorCode.ERR_NAME_NOT_RESOLVED="Server's IP address not found"
+ErrorCode.ERR_TIMED_OUT="Connection timed out"
+ErrorCode.ERR_FILE_NOT_FOUND="File not found"
+ErrorCode.ERR_FAILED="Failed to connect"
+ErrorCode.ERR_NETWORK_CHANGED="Network changed"

--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -4,6 +4,7 @@
 #include <QUrl>
 #include <QDesktopServices>
 
+#include <obs-module.h>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -96,6 +97,47 @@ bool QCefBrowserClient::OnOpenURLFromTab(
 	QUrl url = QUrl(str_url.c_str(), QUrl::TolerantMode);
 	QDesktopServices::openUrl(url);
 	return true;
+}
+
+void QCefBrowserClient::OnLoadError(CefRefPtr<CefBrowser> browser,
+				    CefRefPtr<CefFrame> frame,
+				    CefLoadHandler::ErrorCode errorCode,
+				    const CefString &errorText,
+				    const CefString &failedUrl)
+{
+	if (errorCode == ERR_ABORTED)
+		return;
+
+	struct dstr html;
+	char *path = obs_module_file("error.html");
+	char *errorPage = os_quick_read_utf8_file(path);
+
+	dstr_init_copy(&html, errorPage);
+
+	dstr_replace(&html, "%%ERROR_URL%%", failedUrl.ToString().c_str());
+
+	dstr_replace(&html, "Error.Title", obs_module_text("Error.Title"));
+	dstr_replace(&html, "Error.Description",
+		     obs_module_text("Error.Description"));
+	dstr_replace(&html, "Error.Retry", obs_module_text("Error.Retry"));
+	const char *translError;
+	std::string errorKey = "ErrorCode." + errorText.ToString();
+	if (obs_module_get_string(errorKey.c_str(),
+				  (const char **)&translError)) {
+		dstr_replace(&html, "%%ERROR_CODE%%", translError);
+	} else {
+		dstr_replace(&html, "%%ERROR_CODE%%",
+			     errorText.ToString().c_str());
+	}
+
+	frame->LoadURL(
+		"data:text/html;base64," +
+		CefURIEncode(CefBase64Encode(html.array, html.len), false)
+			.ToString());
+
+	dstr_free(&html);
+	bfree(path);
+	bfree(errorPage);
 }
 
 /* CefLifeSpanHandler */

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -40,6 +40,12 @@ public:
 				    bool user_gesture,
 				    bool is_redirect) override;
 
+	virtual void OnLoadError(CefRefPtr<CefBrowser> browser,
+				 CefRefPtr<CefFrame> frame,
+				 CefLoadHandler::ErrorCode errorCode,
+				 const CefString &errorText,
+				 const CefString &failedUrl) override;
+
 	virtual bool OnOpenURLFromTab(
 		CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 		const CefString &target_url,


### PR DESCRIPTION
### Description
When a browser panel fails to load, show an error screen instead of a blank page. This uses the load handler built into CEF.

![](http://scr.wzd.li/scr/2019-12-28_14-17-32.png)

Text for lines 1, 2 and the link at the bottom are **always** translated via the locale.
Line 3 uses a locale translation if it's available, otherwise it falls back to the raw error code.

In terms of the HTML/CSS itself, it's near-identical to https://obsproject.com/browser-source - minus the white border, and with a smaller logo. This should make it easy to keep the designs in sync. The logo is an SVG so that it can load offline.

### Motivation and Context

While it makes sense for a browser source to turn blank if a webpage fails to load, it does not make sense for a browser panel. With this PR, the user knows why the page failed to load, and has an easy link to reload the page.

### How Has This Been Tested?
* Create a browser panel pointed to an invalid url
* After the timeout period, the error page should be displayed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
