### PR TITLE
Fix CSS injection by using a style element

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -365,19 +365,12 @@ void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame,
 	if (frame->IsMain()) {
 		std::string base64EncodedCSS = base64_encode(bs->css);
 
-		std::string href;
-		href += "data:text/css;charset=utf-8;base64,";
-		href += base64EncodedCSS;
-
 		std::string script;
-		script += "var link = document.createElement('link');";
-		script += "link.setAttribute('rel', 'stylesheet');";
-		script += "link.setAttribute('type', 'text/css');";
-		script += "link.setAttribute('href', '" + href + "');";
-		script +=
-			"document.getElementsByTagName('head')[0].appendChild(link);";
+		script += "const obsCSS = document.createElement('style');";
+		script += "obsCSS.innerHTML = atob(\"" + base64EncodedCSS + "\");";
+		script += "document.querySelector('head').appendChild(obsCSS);";
 
-		frame->ExecuteJavaScript(script, href, 0);
+		frame->ExecuteJavaScript(script, "", 0);
 	}
 }
 


### PR DESCRIPTION
### Description

Uses a `<style>` element, and bas64 encoded text that gets converted back to a string at runtime, to ensure all characters are escaped properly when transferred from C++ to JavaScript.

### Motivation and Context

Custom CSS doesn't load properly on many pages due to their configuration (for valid reason).
`obs-browser: Refused to load the stylesheet 'data:text/css;charset=utf-8;base64,' because it violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' ". Note that 'style-src-elem' was not explicitly set, so 'style-src' is used as a fallback.`

By using a `<style>` element instead of a `<link>`, the CSS is injected safely and consistently.

The reason it didn't load before this PR is because by loading in a `<link>` element, the CSS is considered external - even though it's being loaded 100% internally within the browser source, and without a network call.

### How Has This Been Tested?

Define some custom CSS, like the below, and load it on the default `obsproject.com/browser-source` page. Notice without this change it doesn't load, and with this change, it loads.
```css
html {
    border: solid 10px red;
}
body:before {
    content: "My quotes are properly escaped";
}
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
