### PR TITLE
Use monospace font for Custom CSS property

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -192,8 +192,9 @@ static obs_properties_t *browser_source_get_properties(void *data)
 				obs_module_text("RerouteAudio"));
 
 	obs_properties_add_int(props, "fps", obs_module_text("FPS"), 1, 60, 1);
-	obs_properties_add_text(props, "css", obs_module_text("CSS"),
-				OBS_TEXT_MULTILINE);
+	obs_property_t *p = obs_properties_add_text(
+		props, "css", obs_module_text("CSS"), OBS_TEXT_MULTILINE);
+	obs_property_text_set_monospace(p, true);
 	obs_properties_add_bool(props, "shutdown",
 				obs_module_text("ShutdownSourceNotVisible"));
 	obs_properties_add_bool(props, "restart_when_active",


### PR DESCRIPTION
### Description
![](http://scr.wzd.li/scr/2019-12-29_19-58-05.png)

### Motivation and Context
This significantly improves the usability and readability of the Custom CSS field. More info @ https://github.com/obsproject/obs-studio/pull/2276

### How Has This Been Tested?
Open the properties for a browser source.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
