### PR TITLE
Set icon for browser source

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -327,6 +327,7 @@ void RegisterBrowserSource()
 			    OBS_SOURCE_DO_NOT_DUPLICATE;
 	info.get_properties = browser_source_get_properties;
 	info.get_defaults = browser_source_get_defaults;
+	info.icon_type = OBS_ICON_TYPE_BROWSER;
 
 	info.get_name = [](void *) { return obs_module_text("BrowserSource"); };
 	info.create = [](obs_data_t *settings, obs_source_t *source) -> void * {


### PR DESCRIPTION
### Description
This sets the source icon type for the browser source.

### Motivation and Context
The browser source currently didn't have the icon set.

### How Has This Been Tested?
Ran program, icon worked.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
