### PR TITLE
Fix compiler error in browser source when shared textures are disabled

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -505,6 +505,7 @@ static inline bool is_intel(const std::wstring &str)
 	return wstrstri(str.c_str(), L"Intel") != 0;
 }
 
+#if EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED
 static void check_hwaccel_support(void)
 {
 	/* do not use hardware acceleration if a blacklisted device is the
@@ -527,6 +528,7 @@ static void check_hwaccel_support(void)
 		}
 	}
 }
+#endif
 
 bool obs_module_load(void)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add a missing ifdef of EXPERIMENTAL_SHARED_TEXTURE_SUPPORT_ENABLED, to make the browser source compile on non-win32 platforms where this isn't defined.

### Motivation and Context
The browser source didn't compile on Mac

### How Has This Been Tested?
`ninja`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
