### PR TITLE
Fix loading local files with a hash in the path

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -425,6 +425,18 @@ void BrowserSource::Update(obs_data_t *settings)
 		n_reroute = obs_data_get_bool(settings, "reroute_audio");
 
 		if (n_is_local) {
+			n_url = CefURIEncode(n_url, false);
+
+#ifdef _WIN32
+			n_url.replace(n_url.find("%3A"), 3, ":");
+#endif
+
+			while (n_url.find("%5C") != std::string::npos)
+				n_url.replace(n_url.find("%5C"), 3, "/");
+
+			while (n_url.find("%2F") != std::string::npos)
+				n_url.replace(n_url.find("%2F"), 3, "/");
+
 #if !ENABLE_LOCAL_FILE_URL_SCHEME
 			/* http://absolute/ based mapping for older CEF */
 			n_url = "http://absolute/" + n_url;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change makes it so file paths that contain a hash symbol will load correctly when using local file in the browser source.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change fixes #198 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I created a folder with a hash in the name, added an HTML file to it, and attempted to load the file with the browser source. This testing was done on Windows 10.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
