### PR TITLE
Fix crash when replay buffer events are triggered

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -446,16 +446,16 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		DispatchJSEvent("obsRecordingStopped", "");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
-		DispatchJSEvent("obsReplaybufferStarting", nullptr);
+		DispatchJSEvent("obsReplaybufferStarting", "");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED:
-		DispatchJSEvent("obsReplaybufferStarted", nullptr);
+		DispatchJSEvent("obsReplaybufferStarted", "");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING:
-		DispatchJSEvent("obsReplaybufferStopping", nullptr);
+		DispatchJSEvent("obsReplaybufferStopping", "");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED:
-		DispatchJSEvent("obsReplaybufferStopped", nullptr);
+		DispatchJSEvent("obsReplaybufferStopped", "");
 		break;
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED: {
 		OBSSource source = obs_frontend_get_current_scene();


### PR DESCRIPTION
### Description
Fixes a crash when starting a Replay Buffer. Including on startup.

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
* Have a browser source in a scene
* Either open OBS with --startreplaybuffer or start a replay buffer using the button

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
