### PR TITLE
Use CEF sandbox flags rather than Chromium

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,13 @@ if(MSVC)
 	endforeach()
 	list(APPEND obs-browser_LIBRARIES
 		d3d11
+		Dbghelp
 		dxgi
+		Shlwapi
+		Version
+		wbemuuid
+		Winmm
+		Ws2_32
 		)
 endif()
 

--- a/FindCEF.cmake
+++ b/FindCEF.cmake
@@ -40,6 +40,12 @@ else()
 			${CEF_ROOT_DIR}/build/libcef_dll
 			${CEF_ROOT_DIR}/build/libcef_dll_wrapper)
 	if(WIN32)
+		find_library(CEFSANDBOX_LIBRARY
+			NAMES cef_sandbox.lib
+			PATHS ${CEF_ROOT_DIR}/Release)
+		find_library(CEFSANDBOX_LIBRARY_DEBUG
+			NAMES cef_sandbox.lib
+			PATHS ${CEF_ROOT_DIR}/Debug)
 		find_library(CEFWRAPPER_LIBRARY_DEBUG
 			NAMES cef_dll_wrapper libcef_dll_wrapper
 			PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Debug ${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Debug)
@@ -61,9 +67,11 @@ endif()
 if(WIN32)
 	set(CEF_LIBRARIES
 			${CEF_LIBRARY}
+			optimized ${CEFSANDBOX_LIBRARY}
 			optimized ${CEFWRAPPER_LIBRARY})
 	if (CEFWRAPPER_LIBRARY_DEBUG)
 		list(APPEND CEF_LIBRARIES
+				debug ${CEFSANDBOX_LIBRARY_DEBUG}
 				debug ${CEFWRAPPER_LIBRARY_DEBUG})
 	endif()
 else()

--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -36,6 +36,7 @@
 #include <include/cef_version.h>
 #include <include/cef_render_process_handler.h>
 #include <include/cef_request_context_handler.h>
+#include <include/cef_sandbox_win.h>
 
 #if CHROME_VERSION_BUILD < 3507
 #define ENABLE_WASHIDDEN 1

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -270,7 +270,16 @@ static void BrowserInit(void)
 
 	app = new BrowserApp(tex_sharing_avail);
 	CefExecuteProcess(args, app, nullptr);
-	CefInitialize(args, settings, app, nullptr);
+
+	{
+		void *windows_sandbox_info = NULL;
+#ifdef _WIN32
+		CefScopedSandboxInfo scoped_sandbox;
+		windows_sandbox_info = scoped_sandbox.sandbox_info();
+#endif
+		CefInitialize(args, settings, app, windows_sandbox_info);
+	}
+
 #if !ENABLE_LOCAL_FILE_URL_SCHEME
 	/* Register http://absolute/ scheme handler for older
 	 * CEF builds which do not support file:// URLs */


### PR DESCRIPTION
### Description
Don't use MITIGATION_HARDEN_TOKEN_IL_POLICY flag, or Chromium will mess with the process in a way that breaks Windows 10 window capture.

### Motivation and Context
Windows 10 window capture throws an uncaught exception otherwise.

### How Has This Been Tested?
Windows 10 window capture crashes OBS without the change, and works with the change.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.