### PR TITLE
Slightly improve keyboard events in Interact

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -295,12 +295,13 @@ void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
 	uint32_t modifiers = event->modifiers;
 	std::string text = event->text;
 	uint32_t native_vkey = event->native_vkey;
+	uint32_t native_scancode = event->native_scancode;
 
 	ExecuteOnBrowser(
 		[=](CefRefPtr<CefBrowser> cefBrowser) {
 			CefKeyEvent e;
 			e.windows_key_code = native_vkey;
-			e.native_key_code = 0;
+			e.native_key_code = native_scancode;
 
 			e.type = key_up ? KEYEVENT_KEYUP : KEYEVENT_RAWKEYDOWN;
 


### PR DESCRIPTION
### Description
Provides slightly better keyboard events to the webpage.

On all platforms, tries to provide the `KeyboardEvent.code` where possible
On Windows, this also provides an accurate `KeyboardEvent.key` and `KeyboardEvent.which`
On Linux, currently this provides largely useless key and which (but accurate `KeyboardEvent.code`). The big challenge here is [this is what the CEF tests](https://bitbucket.org/chromiumembedded/cef/src/e0974ea64d02545b594ae7d1e857a9d246c1f188/tests/cefclient/browser/browser_window_osr_gtk.cc?at=master&fileviewer=file-view-default#browser_window_osr_gtk.cc) (with mappings) look like. That's **a lot of code** for a few keypress events.

It's possible a mapping of ascii codes to JS .which values would do the trick for Linux.

### Motivation and Context
Partially improves #200 

### How Has This Been Tested?
Load http://keycode.info in a browser source and a browser panel. Note the differences when interacting with a panel (all keys show correctly) vs the Interact window for a source (largely empty or shows as F7).

Untested on macOS at this time.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
