### PR TITLE
Set default CSS color to white

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -104,6 +104,7 @@ bool QueueCEFTask(std::function<void()> task)
 static const char *default_css = "\
 body { \
 background-color: rgba(0, 0, 0, 0); \
+color: rgb(255, 255, 255); \
 margin: 0px auto; \
 overflow: hidden; \
 }";


### PR DESCRIPTION
### Description
Black text on transparent is invisble with the OBS canvas.

### Motivation and Context
Could not see text at this URL: chrome://version

### How Has This Been Tested?
Can now see text at chrome://version

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.