### PR TITLE
Set a more usable default font size

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -168,6 +168,9 @@ bool BrowserSource::CreateBrowser()
 		cefBrowserSettings.windowless_frame_rate = fps;
 #endif
 
+		cefBrowserSettings.default_font_size = 16;
+		cefBrowserSettings.default_fixed_font_size = 16;
+
 #if ENABLE_LOCAL_FILE_URL_SCHEME
 		if (is_local) {
 			/* Disable web security for file:// URLs to allow


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Set a default font size of 16px to ensure that text is readable when unstyled.

### Motivation and Context
The default font size in most browsers is 16px, but the default here appears sometimes to be 1px. This results in unreadable text (see eg the confusion in #226 which ultimately was caused by this), and is inconsistent.

### How Has This Been Tested?
Fired up several pages. Browser plugin was built against CEF 75.1.14+gc81164e+chromium-75.0.3770.100 - didn't test with other CEF versions. It might be that this patch only benefits older browser builds, but that's still worthwhile as 3770 is the one named in the OBS installation instructions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
