### PR TITLE
Fix Windows key modifiers

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -305,22 +305,25 @@ void BrowserSource::SendFocus(bool focus)
 
 void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
 {
-	uint32_t modifiers = event->modifiers;
-	UNUSED_PARAMETER(modifiers);
 	std::string text = event->text;
 #ifdef __linux__
 	uint32_t native_vkey = KeyboardCodeFromXKeysym(event->native_vkey);
-#else
+	uint32_t modifiers = event->native_modifiers;
+#elif defined(_WIN32)
 	uint32_t native_vkey = event->native_vkey;
-#endif
+	uint32_t modifiers = event->modifiers;
+#else
 	uint32_t native_scancode = event->native_scancode;
-	uint32_t native_modifiers = event->native_modifiers;
+	UNUSED_PARAMETER(modifiers);
+#endif
 
 	ExecuteOnBrowser(
 		[=](CefRefPtr<CefBrowser> cefBrowser) {
 			CefKeyEvent e;
 			e.windows_key_code = native_vkey;
+#ifdef __APPLE__
 			e.native_key_code = native_scancode;
+#endif
 
 			e.type = key_up ? KEYEVENT_KEYUP : KEYEVENT_RAWKEYDOWN;
 
@@ -331,7 +334,7 @@ void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
 			}
 
 			//e.native_key_code = native_vkey;
-			e.modifiers = native_modifiers;
+			e.modifiers = modifiers;
 
 			cefBrowser->GetHost()->SendKeyEvent(e);
 			if (!text.empty() && !key_up) {
@@ -339,10 +342,11 @@ void BrowserSource::SendKeyClick(const struct obs_key_event *event, bool key_up)
 #ifdef __linux__
 				e.windows_key_code =
 					KeyboardCodeFromXKeysym(e.character);
-#else
+#elif defined(_WIN32)
 				e.windows_key_code = e.character;
-#endif
+#else
 				e.native_key_code = native_scancode;
+#endif
 				cefBrowser->GetHost()->SendKeyEvent(e);
 			}
 		},


### PR DESCRIPTION
### Description
I have altered the code responsible for key modifiers. Changes in #206 broke support on Windows, new logic has been implemented to return support.
Other values such as native_scancode should probably also be investigated, but I am not a linux desktop user.

### Motivation and Context
This will solve issues https://github.com/obsproject/obs-studio/issues/3307 and [dicsussions on the forum](https://obsproject.com/forum/threads/in-browser-source-stopped-working-copy-paste.118812/)

### How Has This Been Tested?
I have only tested this on windows, while I had backported obs studio to tag 25.0.1, I do not believe this will be an issue in regards to the patch.
Testing on both linux and macos would be appreciated. I have read that `native` is also a thing for mac users in this [CEF thread](https://magpcss.org/ceforum/viewtopic.php?f=6&t=13560), therefore it is likely a further change will be needed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
