### PR TITLE
Fix Xcode linking issues introduced by Cmake 3.19.0

### DIFF
--- a/FindCEF.cmake
+++ b/FindCEF.cmake
@@ -67,9 +67,19 @@ if(WIN32)
 				debug ${CEFWRAPPER_LIBRARY_DEBUG})
 	endif()
 else()
-	set(CEF_LIBRARIES
-			${CEF_LIBRARY}
-			${CEFWRAPPER_LIBRARY})
+	# Fixes cmake 3.19.0 commit that added support for modern Xcode build system, but "forgot"
+	# to also escape framework names themselves in addition to the framework path:
+	# Commit https://gitlab.kitware.com/cmake/cmake/-/commit/ce2dee9e5bae37c8117087bb83add075c3c123b4
+	if(${CMAKE_VERSION} VERSION_GREATER "3.19.0" AND XCODE)
+		string(REPLACE "Chromium Embedded Framework" "\"Chromium Embedded Framework\"" CEF_LIBRARY_FIXED ${CEF_LIBRARY})
+		set(CEF_LIBRARIES
+				${CEF_LIBRARY_FIXED}
+				${CEFWRAPPER_LIBRARY})
+	else()
+		set(CEF_LIBRARIES
+				${CEF_LIBRARY}
+				${CEFWRAPPER_LIBRARY})
+	endif()
 endif()
 
 find_package_handle_standard_args(CEF DEFAULT_MSG CEF_LIBRARY


### PR DESCRIPTION
### Description
Fixes Xcode build failing when created with Cmake 3.19.0+ and updates minimum supported macOS version to align with the main project.

### Motivation and Context
Cmake 3.19.0+ switched to Xcode's modern build system, which also changed the way frameworks are linked/added to the project. Whereas https://gitlab.kitware.com/cmake/cmake/-/commit/ce2dee9e5bae37c8117087bb83add075c3c123b4 added support to escape the framework *path*, it doesn't escape the framework *name* which in the case of CEF contains spaces and breaks the `LDFLAG` setting.

### How Has This Been Tested?
* OBS successfully configured and compiled with Xcode
* OBS successfully configured and compiled from CLI

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
