### PR TITLE
Add Linux browser panel support [CEF 4280 / Chromium 87]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,9 +137,7 @@ if (APPLE)
 		)
 endif()
 
-# only allow browser panels on win32 for now -- other operating systems
-# need more testing
-if((WIN32 OR APPLE) AND BROWSER_PANEL_SUPPORT_ENABLED)
+if(BROWSER_PANEL_SUPPORT_ENABLED)
 	list(APPEND obs-browser_SOURCES
 		panel/browser-panel.cpp
 		panel/browser-panel-client.cpp

--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -55,6 +55,8 @@ public:
 	std::string script;
 	CefRefPtr<CefRequestContext> rqc;
 	QTimer timer;
+	QPointer<QWindow> window;
+	QPointer<QWidget> container;
 	bool allowAllPopups_ = false;
 
 	virtual void resizeEvent(QResizeEvent *event) override;

--- a/panel/browser-panel.hpp
+++ b/panel/browser-panel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <obs-module.h>
 #include <util/platform.h>
 #include <util/util.hpp>
 #include <QWidget>
@@ -72,36 +73,46 @@ struct QCef {
 					 QObject *obj) = 0;
 };
 
-static inline void *obs_browser_dlsym(const char *name)
+static inline void *get_browser_lib()
 {
-#if defined(_WIN32)
-	void *lib = os_dlopen("obs-browser");
-#elif defined(__APPLE__)
-	void *lib = RTLD_DEFAULT;
-#else
-	void *lib = os_dlopen("../obs-plugins/obs-browser");
-#endif
-	if (!lib) {
-		return nullptr;
-	}
+	obs_module_t *browserModule = obs_get_module("obs-browser");
 
-	return os_dlsym(lib, name);
+	if (!browserModule)
+		return nullptr;
+
+	return obs_get_module_lib(browserModule);
 }
 
 static inline QCef *obs_browser_init_panel(void)
 {
-	QCef *(*create_qcef)(void) = (decltype(create_qcef))obs_browser_dlsym(
-		"obs_browser_create_qcef");
+	void *lib = get_browser_lib();
+	QCef *(*create_qcef)(void) = nullptr;
+
+	if (!lib)
+		return nullptr;
+
+	create_qcef =
+		(decltype(create_qcef))os_dlsym(lib, "obs_browser_create_qcef");
+
 	if (!create_qcef)
 		return nullptr;
+
 	return create_qcef();
 }
 
 static inline int obs_browser_qcef_version(void)
 {
-	int (*qcef_version)(void) = (decltype(qcef_version))obs_browser_dlsym(
-		"obs_browser_qcef_version_export");
+	void *lib = get_browser_lib();
+	int (*qcef_version)(void) = nullptr;
+
+	if (!lib)
+		return 0;
+
+	qcef_version = (decltype(qcef_version))os_dlsym(
+		lib, "obs_browser_qcef_version_export");
+
 	if (!qcef_version)
 		return 0;
+
 	return qcef_version();
 }


### PR DESCRIPTION
### TODO
- [x] Needs more testing (tested on Ubuntu 20.04 with QT 5.12.8)
- [x] Un-hardcode obs-browser.so lookup
- [x] Fix random crashes that sometimes happen

### Description
Add Linux browser panel support.

![Screenshot from 2020-12-08 14-39-41](https://user-images.githubusercontent.com/19962531/101541058-76f2c080-3966-11eb-845f-a946f41ae851.png)

### Motivation and Context
Bringing the browser plugin to parity with Windows.

### How Has This Been Tested?
Needs testing on other OSs to make sure it doesn't break anything.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
