### PR TITLE
Initialize CEF early to fix macOS crash

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -592,6 +592,12 @@ bool obs_module_load(void)
 	}
 	obs_data_release(private_data);
 #endif
+
+#if defined(__APPLE__) && CHROME_VERSION_BUILD < 4183
+	// Make sure CEF malloc hijacking happens early in the process
+	obs_browser_initialize();
+#endif
+
 	return true;
 }
 


### PR DESCRIPTION
### Description

Initialize CEF during `obs_module_load()` to prevent a crash in Chrome's memory allocation handler.

### Motivation and Context

If CEF is initialized after CoreAudio on macOS Big Sur, it trips a bug in Chrome that causes a crash.

I'm tired of my OBS crashing unless I specifically open a Scene Collection with only a Browser in it before opening the Scene Collections I want to open.

### How Has This Been Tested?

I opened OBS and it doesn't crash.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
