### PR TITLE
Disable hwaccel on 10.14 and lower

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,14 @@ set(obs-browser_LIBRARIES
 list(APPEND obs-browser_LIBRARIES
 	${CEF_LIBRARIES})
 
+if (APPLE)
+	find_library(COREFOUNDATION CoreFoundation)
+	find_library(APPKIT AppKit)
+	list(APPEND obs-browser_LIBRARIES
+			${COREFOUNDATION}
+			${APPKIT})
+endif()
+
 if(BROWSER_PANEL_SUPPORT_ENABLED OR USE_QT_LOOP)
 	if(DEFINED QTDIR${_lib_suffix})
 		list(APPEND CMAKE_PREFIX_PATH "${QTDIR${_lib_suffix}}")
@@ -122,6 +130,12 @@ set(obs-browser_HEADERS
 	deps/wide-string.hpp
 	cef-headers.hpp
 	)
+
+if (APPLE)
+	list(APPEND obs-browser_SOURCES
+		macutil.mm
+		)
+endif()
 
 # only allow browser panels on win32 for now -- other operating systems
 # need more testing

--- a/macutil.mm
+++ b/macutil.mm
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+bool atLeast10_15(void)
+{
+	NSProcessInfo *processInfo = [[NSProcessInfo alloc] init];
+	bool atLeast = [processInfo
+		isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){
+							10, 15, 0}];
+	[processInfo release];
+
+	return atLeast;
+}

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -559,6 +559,18 @@ static void check_hwaccel_support(void)
 		}
 	}
 }
+#elif defined(__APPLE__)
+extern bool atLeast10_15(void);
+
+static void check_hwaccel_support(void)
+{
+	if (!atLeast10_15()) {
+		blog(LOG_INFO,
+		     "[obs-browser]: OS version older than 10.15 Disabling hwaccel");
+		hwaccel = false;
+	}
+	return;
+}
 #else
 static void check_hwaccel_support(void)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Disables hardware acceleration on macOS lower than 10.15

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Hardware acceleration would prevent the browser source from working on macOS 10.14 and lower

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->


Ran on 10.13 10.15 11.1 11.2

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
