### PR TITLE
Render as linear SRGB

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -552,8 +552,11 @@ void BrowserSource::Render()
 		gs_effect_t *effect =
 			obs_get_base_effect(OBS_EFFECT_PREMULTIPLIED_ALPHA);
 #endif
+
+		const bool previous = gs_set_linear_srgb(true);
 		while (gs_effect_loop(effect, "Draw"))
 			obs_source_draw(texture, 0, 0, 0, 0, flip);
+		gs_set_linear_srgb(previous);
 	}
 
 #if defined(_WIN32) && defined(SHARED_TEXTURE_SUPPORT_ENABLED)


### PR DESCRIPTION
### Description
Render browser source in linear space.

TODO: Requires obsproject/obs-studio/pull/2067

### Motivation and Context
Fixes alpha blending in particular.

### How Has This Been Tested?
50% white text is now 188 instead of 127.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.