### PR TITLE
Add missing files check for local browser sources

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -214,6 +214,51 @@ static obs_properties_t *browser_source_get_properties(void *data)
 	return props;
 }
 
+static void missing_file_callback(void *src, const char *new_path, void *data)
+{
+	BrowserSource *bs = static_cast<BrowserSource *>(src);
+
+	if (bs) {
+		obs_source_t *source = bs->source;
+		obs_data_t *settings = obs_source_get_settings(source);
+		obs_data_set_string(settings, "local_file", new_path);
+		obs_source_update(source, settings);
+		obs_data_release(settings);
+	}
+
+	UNUSED_PARAMETER(data);
+}
+
+static obs_missing_files_t *browser_source_missingfiles(void *data)
+{
+	BrowserSource *bs = static_cast<BrowserSource *>(data);
+	obs_missing_files_t *files = obs_missing_files_create();
+
+	if (bs) {
+		obs_source_t *source = bs->source;
+		obs_data_t *settings = obs_source_get_settings(source);
+
+		bool enabled = obs_data_get_bool(settings, "is_local_file");
+		const char *path = obs_data_get_string(settings, "local_file");
+
+		if (enabled && strcmp(path, "") != 0) {
+			if (!os_file_exists(path)) {
+				obs_missing_file_t *file =
+					obs_missing_file_create(
+						path, missing_file_callback,
+						OBS_MISSING_FILE_SOURCE,
+						bs->source, NULL);
+
+				obs_missing_files_add_file(files, file);
+			}
+		}
+
+		obs_data_release(settings);
+	}
+
+	return files;
+}
+
 static CefRefPtr<BrowserApp> app;
 
 static void BrowserInit(void)
@@ -370,6 +415,7 @@ void RegisterBrowserSource()
 	info.destroy = [](void *data) {
 		delete static_cast<BrowserSource *>(data);
 	};
+	info.missing_files = browser_source_missingfiles;
 	info.update = [](void *data, obs_data_t *settings) {
 		static_cast<BrowserSource *>(data)->Update(settings);
 	};


### PR DESCRIPTION
### Description

Adds support for reporting missing files using the API that came in https://github.com/obsproject/obs-studio/pull/2233.

Limited to Local File mode only, of course.

![image](https://user-images.githubusercontent.com/941350/106438146-33ca4f00-64ca-11eb-94d2-2252dee3a9ec.png)

To match the below snippet, I also added a basic `if (bs)` check just in case. You never know what CEF will do.

https://github.com/obsproject/obs-browser/blob/d2c9fef1018aee8c2f78312011da25e1abcbe124/obs-browser-plugin.cpp#L165

### Motivation and Context

Reporting errors to the user is good. Using new features is also good.

### How Has This Been Tested?

* Create a number of browser sources, including a couple in local file mode.
* Close OBS, then delete the file selected in one of the local sources
* Reopen OBS
* See dialog, point it to a new location for the file
* See the source correctly update

**Note:** I did run into one application hang while the dialog was open, but I'm not sure if it was caused by my changes or just a side effect of the browser doing its thing on startup.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
