### PR TITLE
Fix unnecessary pixel ratio calculations on macOS

### DIFF
--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -55,8 +55,10 @@ public:
 	std::string script;
 	CefRefPtr<CefRequestContext> rqc;
 	QTimer timer;
+#ifndef __APPLE__
 	QPointer<QWindow> window;
 	QPointer<QWidget> container;
+#endif
 	bool allowAllPopups_ = false;
 
 	virtual void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
### Description
Disables unnecessary pixel ratio calculations on macOS which led to CEF window size and Qt window size mismatches.

Fixes https://github.com/obsproject/obs-browser/issues/265.

### Motivation and Context
Window sizes in macOS are automatically translated to actual pixel sizes internally by macOS, applications are required to work with "logical" sizes (aka "dots") instead. Thus applying pixel ratios as multipliers is not necessary.

### How Has This Been Tested?
* Applied to local build on macOS and tested with attached and detached browser panels.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
