### PR TITLE
Fix cmake option set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,10 @@ if(NOT CEF_FOUND)
 	return()
 endif()
 
-option(SHARED_TEXTURE_SUPPORT_ENABLED "Enable shared texture support for the browser plugin" OFF)
 if(WIN32 OR (APPLE AND NOT BROWSER_LEGACY))
-    set(SHARED_TEXTURE_SUPPORT_ENABLED ON)
+    option(SHARED_TEXTURE_SUPPORT_ENABLED "Enable shared texture support for the browser plugin" ON)
+else()
+    option(SHARED_TEXTURE_SUPPORT_ENABLED "Enable shared texture support for the browser plugin" OFF)
 endif()
 
 option(BROWSER_PANEL_SUPPORT_ENABLED "Enables Qt web browser panel support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(BROWSER_PANEL_SUPPORT_ENABLED "Enables Qt web browser panel support" ON)
 if(NOT APPLE)
 	option(USE_QT_LOOP "Runs CEF on the main UI thread alongside Qt instead of in its own thread" OFF)
 else()
-	set(USE_QT_LOOP ON)
+	option(USE_QT_LOOP "Runs CEF on the main UI thread alongside Qt instead of in its own thread" ON)
 endif()
 
 if(UNIX AND NOT APPLE)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix Shared Texture option in cmake-gui
Fix USE_QT_LOOP option in cmake-gui

When using `set` without specifying the CACHE argument, a normal/local variable is set to the specified value. This results in the GUI showing the CACHE variable value (OFF), but the rest of the CMake script checks the normal variable value first. Thus, the script works as if `SHARED_TEXTURE_SUPPORT_ENABLED` is set to ON, even though cmake-gui shows it set to OFF.

By default, cmake-gui on Windows would show `SHARED_TEXTURE_SUPPORT_ENABLED` as OFF, as specified by the initial `option` call.  The `option` call would set a CACHE variable in CMake.  The subsequent `set` call would then set a normal/local CMake variable to ON.  When CMake checks variables, it checks for a normal variable value first, and uses that value if found.  Because of this, the script would continue on as if `SHARED_TEXTURE_SUPPORT_ENABLED` was ON, even though cmake-gui showed it as OFF.

This PR fixes the behavior for both `SHARED_TEXTURE_SUPPORT_ENABLED` and `USE_QT_LOOP`.

Before:
![image](https://user-images.githubusercontent.com/624931/110840789-25164b00-8273-11eb-9b2b-ee1a74b3d108.png)

After:
![image](https://user-images.githubusercontent.com/624931/110840815-2c3d5900-8273-11eb-9a6e-5b27cff4648e.png)

Alternatively, we could use a temporary normal variable to set the value and use a single option call.  I think it's a bit messier with just a couple boolean values, but I'm open to either solution.
```
set(SHARED_TEXTURE_SUPPORT_ENABLED OFF)
if(WIN32 OR (APPLE AND NOT BROWSER_LEGACY))
    set(SHARED_TEXTURE_SUPPORT_ENABLED ON)
endif()
option(SHARED_TEXTURE_SUPPORT_ENABLED "Enable shared texture support for the browser plugin" ${SHARED_TEXTURE_SUPPORT_ENABLED})
unset(SHARED_TEXTURE_SUPPORT_ENABLED)
```

References:
https://cmake.org/cmake/help/v3.19/command/option.html
https://cmake.org/cmake/help/v3.19/command/set.html
https://cmake.org/cmake/help/v3.19/command/unset.html
https://cmake.org/cmake/help/v3.19/variable/CACHE.html
https://cmake.org/cmake/help/v3.19/manual/cmake-language.7.html#variables
https://cmake.org/cmake/help/v3.19/manual/cmake-language.7.html#variable-references
https://cmake.org/cmake/help/v3.19/policy/CMP0077.html


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Having the GUI reflect values inconsistent from what the CMakeLists script evaluates is bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled OBS with obs-browser on Windows 10 64-bit and tested browser source and browser panels.  Everything seemed to work fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
