### PR TITLE
Only use GPU SRGB if source texture supports it

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -558,7 +558,9 @@ void BrowserSource::Render()
 			obs_get_base_effect(OBS_EFFECT_PREMULTIPLIED_ALPHA);
 #endif
 
-		const bool previous = gs_set_linear_srgb(true);
+		const bool current =
+			gs_is_srgb_format(gs_texture_get_color_format(texture));
+		const bool previous = gs_set_linear_srgb(current);
 		while (gs_effect_loop(effect, "Draw"))
 			obs_source_draw(texture, 0, 0, 0, 0, flip);
 		gs_set_linear_srgb(previous);


### PR DESCRIPTION
### Description
The source texture may not be an SRGB format under the hood.

### Motivation and Context
Was getting bad colors from CEF generated texture.

### How Has This Been Tested?
Colors of default placeholder texture look fine now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.