### PR TITLE
Remove fractional scaling ifdefs

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -41,10 +41,6 @@ CefRefPtr<CefCookieManager> QCefRequestContextHandler::GetCookieManager()
 }
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-#define SUPPORTS_FRACTIONAL_SCALING
-#endif
-
 class CookieCheck : public CefCookieVisitor {
 public:
 	QCefCookieManager::cookie_exists_cb callback;
@@ -244,11 +240,7 @@ void QCefWidgetInternal::Init()
 #ifndef __APPLE__
 	WId handle = window->winId();
 	QSize size = this->size();
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	size *= devicePixelRatioF();
-#else
-	size *= devicePixelRatio();
-#endif
 	bool success = QueueCEFTask(
 		[this, handle, size]()
 #else
@@ -314,11 +306,7 @@ void QCefWidgetInternal::resizeEvent(QResizeEvent *event)
 
 void QCefWidgetInternal::Resize()
 {
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	QSize size = this->size() * devicePixelRatioF();
-#else
-	QSize size = this->size() * devicePixelRatio();
-#endif
 
 	bool success = QueueCEFTask([this, size]() {
 		if (!cefBrowser)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove ifdefs for fractional scaling support (Qt 5.6+).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Among the systems we officially support, the oldest Qt version is Qt 5.9 on Ubuntu 18.04. Fractional scaling is supported in Qt 5.6 and newer. We should be able to safely remove these ifdefs and simplify the code.

@WizardCM Wanted me to check what Qt versions FreeBSD and Arch currently offer, and they both offer Qt 5.15.2.  Xenial (Ubuntu 16.04) still has Qt 5.5, but we no longer officially support that platform, and its End of Standard Support  is April 2021, so I don't think we need to worry about it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran OBS and obs-browser on Windows 10 64-bit with these changes.  I verified that browser docks behave the same in OBS Studio 26.1.1 and after this patch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
