### PR TITLE
Fix memory corruption when translating Refresh text

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -207,7 +207,7 @@ void QCefBrowserClient::OnBeforeContextMenu(CefRefPtr<CefBrowser>,
 	     !model->IsVisible(MENU_ID_RELOAD_NOCACHE))) {
 		model->InsertItemAt(
 			2, MENU_ID_RELOAD_NOCACHE,
-			CefString(QObject::tr("RefreshBrowser").toStdString()));
+			QObject::tr("RefreshBrowser").toUtf8().constData());
 	}
 	if (model->IsVisible(MENU_ID_PRINT)) {
 		model->Remove(MENU_ID_PRINT);


### PR DESCRIPTION
### Description

After testing a variety of solutions, including moving everything into the Qt/UI thread, it seems `.toStdString()` was causing memory corruption. Using `.toUtf8().constData()` directly seems to solve the issue.

### Motivation and Context

This fixes a crash / memory corruption.

### How Has This Been Tested?

Right click on a browser panel on Windows.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
