### PR TITLE
Add Browser Source Refresh Hotkey

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -72,6 +72,20 @@ void DispatchJSEvent(std::string eventName, std::string jsonString,
 BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_)
 	: source(source_)
 {
+
+	/* Register Refresh hotkey */
+	auto refreshFunction = [](void *data, obs_hotkey_id, obs_hotkey_t *,
+				  bool pressed) {
+		if (pressed) {
+			BrowserSource *bs = (BrowserSource *)data;
+			bs->Refresh();
+		}
+	};
+
+	obs_hotkey_register_source(source, "ObsBrowser.Refresh",
+				   obs_module_text("RefreshNoCache"),
+				   refreshFunction, (void *)this);
+
 	/* defer update */
 	obs_source_update(source, nullptr);
 


### PR DESCRIPTION
Adds a hotkey to the browser source that refreshes its cache, the same
way the button in the settings does

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a Hotkey to the browser source that, when triggered, refreshes the browsers cache.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw a Discord conversation asking for a feature like this.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled with current master of obs-studio
Triggering the hotkey will refresh the page as intended.

macOS 11.2.3

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
