### PR TITLE
Change product_version to user_agent_product

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -298,7 +298,11 @@ static void BrowserInit(void)
 	prod_ver << std::to_string(obs_maj) << "." << std::to_string(obs_min)
 		 << "." << std::to_string(obs_pat);
 
+#if CHROME_VERSION_BUILD >= 4472
+	CefString(&settings.user_agent_product) = prod_ver.str();
+#else
 	CefString(&settings.product_version) = prod_ver.str();
+#endif
 
 #ifdef USE_QT_LOOP
 	settings.external_message_pump = true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes compilation against CEF 91.1.0 and later. The `product_version` setting has been renamed to `user_agent_product`.

(Note: only merge this once you update the officially supported CEF to 91.1.0 (Chromium 91.0.4472.19) or later)

### Motivation and Context

Fixes a compilation failure. Here's the [CEF commit](https://bitbucket.org/chromiumembedded/cef/commits/02ae4597d8b6c895e46891a7596cf5fa1fe15df8) that caused this.

### How Has This Been Tested?

Built as part of OBS 27.0 using CEF 90.6.7 on NixOS (see https://github.com/NixOS/nixpkgs/pull/126505).

OBS starts up and displays the chosen web page when a Browser source is configured.

### Types of changes

<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
