### PR TITLE
Remove old CEF ifdefs

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -50,16 +50,9 @@ CefRefPtr<CefBrowserProcessHandler> BrowserApp::GetBrowserProcessHandler()
 
 void BrowserApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 {
-#if CHROME_VERSION_BUILD >= 3683
 	registrar->AddCustomScheme("http",
 				   CEF_SCHEME_OPTION_STANDARD |
 					   CEF_SCHEME_OPTION_CORS_ENABLED);
-#elif CHROME_VERSION_BUILD >= 3029
-	registrar->AddCustomScheme("http", true, false, false, false, true,
-				   false);
-#else
-	registrar->AddCustomScheme("http", true, false, false, false, true);
-#endif
 }
 
 void BrowserApp::OnBeforeChildProcessLaunch(
@@ -247,9 +240,7 @@ void BrowserApp::SetDocumentVisibility(CefRefPtr<CefBrowser> browser,
 #endif
 
 bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-#if CHROME_VERSION_BUILD >= 3770
 					  CefRefPtr<CefFrame> frame,
-#endif
 					  CefProcessId source_process,
 					  CefRefPtr<CefProcessMessage> message)
 {

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -100,9 +100,7 @@ public:
 				      CefRefPtr<CefV8Context> context) override;
 	virtual bool
 	OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-#if CHROME_VERSION_BUILD >= 3770
 				 CefRefPtr<CefFrame> frame,
-#endif
 				 CefProcessId source_process,
 				 CefRefPtr<CefProcessMessage> message) override;
 	virtual bool Execute(const CefString &name,

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -57,12 +57,10 @@ CefRefPtr<CefContextMenuHandler> BrowserClient::GetContextMenuHandler()
 	return this;
 }
 
-#if CHROME_VERSION_BUILD >= 3683
 CefRefPtr<CefAudioHandler> BrowserClient::GetAudioHandler()
 {
 	return reroute_audio ? this : nullptr;
 }
-#endif
 
 #if CHROME_VERSION_BUILD >= 4638
 CefRefPtr<CefRequestHandler> BrowserClient::GetRequestHandler()
@@ -94,10 +92,7 @@ bool BrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 				  cef_window_open_disposition_t, bool,
 				  const CefPopupFeatures &, CefWindowInfo &,
 				  CefRefPtr<CefClient> &, CefBrowserSettings &,
-#if CHROME_VERSION_BUILD >= 3770
-				  CefRefPtr<CefDictionaryValue> &,
-#endif
-				  bool *)
+				  CefRefPtr<CefDictionaryValue> &, bool *)
 {
 	/* block popups */
 	return true;
@@ -113,11 +108,8 @@ void BrowserClient::OnBeforeContextMenu(CefRefPtr<CefBrowser>,
 }
 
 bool BrowserClient::OnProcessMessageReceived(
-	CefRefPtr<CefBrowser> browser,
-#if CHROME_VERSION_BUILD >= 3770
-	CefRefPtr<CefFrame>,
-#endif
-	CefProcessId, CefRefPtr<CefProcessMessage> message)
+	CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, CefProcessId,
+	CefRefPtr<CefProcessMessage> message)
 {
 	const std::string &name = message->GetName();
 	Json json;
@@ -207,29 +199,16 @@ bool BrowserClient::OnProcessMessageReceived(
 
 	return true;
 }
-#if CHROME_VERSION_BUILD >= 3578
-void BrowserClient::GetViewRect(
-#else
-bool BrowserClient::GetViewRect(
-#endif
-	CefRefPtr<CefBrowser>, CefRect &rect)
+
+void BrowserClient::GetViewRect(CefRefPtr<CefBrowser>, CefRect &rect)
 {
 	if (!bs) {
-#if CHROME_VERSION_BUILD >= 3578
 		rect.Set(0, 0, 16, 16);
 		return;
-#else
-		return false;
-#endif
 	}
 
 	rect.Set(0, 0, bs->width < 1 ? 1 : bs->width,
 		 bs->height < 1 ? 1 : bs->height);
-#if CHROME_VERSION_BUILD >= 3578
-	return;
-#else
-	return true;
-#endif
 }
 
 bool BrowserClient::OnTooltip(CefRefPtr<CefBrowser>, CefString &text)
@@ -357,7 +336,6 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>,
 }
 #endif
 
-#if CHROME_VERSION_BUILD >= 3683
 static speaker_layout GetSpeakerLayout(CefAudioHandler::ChannelLayout cefLayout)
 {
 	switch (cefLayout) {
@@ -384,7 +362,6 @@ static speaker_layout GetSpeakerLayout(CefAudioHandler::ChannelLayout cefLayout)
 		return SPEAKERS_UNKNOWN;
 	}
 }
-#endif
 
 #if CHROME_VERSION_BUILD >= 4103
 void BrowserClient::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
@@ -470,7 +447,7 @@ bool BrowserClient::GetAudioParameters(CefRefPtr<CefBrowser> browser,
 	params.frames_per_buffer = kFramesPerBuffer;
 	return true;
 }
-#elif CHROME_VERSION_BUILD >= 3683 && CHROME_VERSION_BUILD < 4103
+#elif CHROME_VERSION_BUILD < 4103
 void BrowserClient::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser, int id,
 					 int, ChannelLayout channel_layout,
 					 int sample_rate, int)
@@ -572,9 +549,7 @@ void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame,
 }
 
 bool BrowserClient::OnConsoleMessage(CefRefPtr<CefBrowser>,
-#if CHROME_VERSION_BUILD >= 3282
 				     cef_log_severity_t level,
-#endif
 				     const CefString &message,
 				     const CefString &source, int line)
 {

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -35,9 +35,7 @@ class BrowserClient : public CefClient,
 #endif
 		      public CefContextMenuHandler,
 		      public CefRenderHandler,
-#if CHROME_VERSION_BUILD >= 3683
 		      public CefAudioHandler,
-#endif
 		      public CefLoadHandler {
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
@@ -83,23 +81,17 @@ public:
 #endif
 	virtual CefRefPtr<CefContextMenuHandler>
 	GetContextMenuHandler() override;
-#if CHROME_VERSION_BUILD >= 3683
 	virtual CefRefPtr<CefAudioHandler> GetAudioHandler() override;
-#endif
 
 	virtual bool
 	OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-#if CHROME_VERSION_BUILD >= 3770
 				 CefRefPtr<CefFrame> frame,
-#endif
 				 CefProcessId source_process,
 				 CefRefPtr<CefProcessMessage> message) override;
 
 	/* CefDisplayHandler */
 	virtual bool OnConsoleMessage(CefRefPtr<CefBrowser> browser,
-#if CHROME_VERSION_BUILD >= 3282
 				      cef_log_severity_t level,
-#endif
 				      const CefString &message,
 				      const CefString &source,
 				      int line) override;
@@ -115,9 +107,7 @@ public:
 		      bool user_gesture, const CefPopupFeatures &popupFeatures,
 		      CefWindowInfo &windowInfo, CefRefPtr<CefClient> &client,
 		      CefBrowserSettings &settings,
-#if CHROME_VERSION_BUILD >= 3770
 		      CefRefPtr<CefDictionaryValue> &extra_info,
-#endif
 		      bool *no_javascript_access) override;
 #if CHROME_VERSION_BUILD >= 4638
 	/* CefRequestHandler */
@@ -143,12 +133,8 @@ public:
 			    CefRefPtr<CefMenuModel> model) override;
 
 	/* CefRenderHandler */
-#if CHROME_VERSION_BUILD >= 3578
-	virtual void GetViewRect(
-#else
-	virtual bool GetViewRect(
-#endif
-		CefRefPtr<CefBrowser> browser, CefRect &rect) override;
+	virtual void GetViewRect(CefRefPtr<CefBrowser> browser,
+				 CefRect &rect) override;
 	virtual void OnPaint(CefRefPtr<CefBrowser> browser,
 			     PaintElementType type, const RectList &dirtyRects,
 			     const void *buffer, int width,
@@ -175,7 +161,7 @@ public:
 	const int kFramesPerBuffer = 1024;
 	virtual bool GetAudioParameters(CefRefPtr<CefBrowser> browser,
 					CefAudioParameters &params) override;
-#elif CHROME_VERSION_BUILD >= 3683
+#else
 	virtual void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
 					 int audio_stream_id,
 					 const float **data, int frames,

--- a/browser-scheme.hpp
+++ b/browser-scheme.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <fstream>
 
-#if CHROME_VERSION_BUILD >= 3440 && CHROME_VERSION_BUILD < 4638
+#if CHROME_VERSION_BUILD < 4638
 #define ENABLE_LOCAL_FILE_URL_SCHEME 1
 #else
 #define ENABLE_LOCAL_FILE_URL_SCHEME 0

--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -40,22 +40,17 @@
 #include "include/wrapper/cef_library_loader.h"
 #endif
 
-#if CHROME_VERSION_BUILD < 3507 || CHROME_VERSION_BUILD >= 4430
+#if CHROME_VERSION_BUILD >= 4430
 #define ENABLE_WASHIDDEN 1
 #else
 #define ENABLE_WASHIDDEN 0
 #endif
 
-#if CHROME_VERSION_BUILD >= 3770
 #define SendBrowserProcessMessage(browser, pid, msg)             \
 	CefRefPtr<CefFrame> mainFrame = browser->GetMainFrame(); \
 	if (mainFrame) {                                         \
 		mainFrame->SendProcessMessage(pid, msg);         \
 	}
-#else
-#define SendBrowserProcessMessage(browser, pid, msg) \
-	browser->SendProcessMessage(pid, msg);
-#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -436,10 +436,7 @@ void RegisterBrowserSource()
 	struct obs_source_info info = {};
 	info.id = "browser_source";
 	info.type = OBS_SOURCE_TYPE_INPUT;
-	info.output_flags = OBS_SOURCE_VIDEO |
-#if CHROME_VERSION_BUILD >= 3683
-			    OBS_SOURCE_AUDIO |
-#endif
+	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_AUDIO |
 			    OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_INTERACTION |
 			    OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB;
 	info.get_properties = browser_source_get_properties;
@@ -470,7 +467,7 @@ void RegisterBrowserSource()
 	info.video_render = [](void *data, gs_effect_t *) {
 		static_cast<BrowserSource *>(data)->Render();
 	};
-#if CHROME_VERSION_BUILD >= 3683 && CHROME_VERSION_BUILD < 4103
+#if CHROME_VERSION_BUILD < 4103
 	info.audio_mix = [](void *data, uint64_t *ts_out,
 			    struct audio_output_data *audio_output,
 			    size_t channels, size_t sample_rate) {

--- a/obs-browser-source-audio.cpp
+++ b/obs-browser-source-audio.cpp
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 #include "obs-browser-source.hpp"
-#if CHROME_VERSION_BUILD < 4103 && CHROME_VERSION_BUILD >= 3683
+#if CHROME_VERSION_BUILD < 4103
 void BrowserSource::EnumAudioStreams(obs_source_enum_proc_t cb, void *param)
 {
 	std::lock_guard<std::mutex> lock(audio_sources_mutex);

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -145,9 +145,6 @@ bool BrowserSource::CreateBrowser()
 					  reroute_audio, webpage_control_level);
 
 		CefWindowInfo windowInfo;
-#if CHROME_VERSION_BUILD < 3071
-		windowInfo.transparent_painting_enabled = true;
-#endif
 #if CHROME_VERSION_BUILD < 4430
 		windowInfo.width = width;
 		windowInfo.height = height;
@@ -194,14 +191,9 @@ bool BrowserSource::CreateBrowser()
 #endif
 		cefBrowser = CefBrowserHost::CreateBrowserSync(
 			windowInfo, browserClient, url, cefBrowserSettings,
-#if CHROME_VERSION_BUILD >= 3770
-			CefRefPtr<CefDictionaryValue>(),
-#endif
-			nullptr);
-#if CHROME_VERSION_BUILD >= 3683
+			CefRefPtr<CefDictionaryValue>(), nullptr);
 		if (reroute_audio)
 			cefBrowser->GetHost()->SetAudioMuted(true);
-#endif
 		if (obs_source_showing(source))
 			is_showing = true;
 
@@ -233,7 +225,7 @@ void BrowserSource::DestroyBrowser(bool async)
 
 	cefBrowser = nullptr;
 }
-#if CHROME_VERSION_BUILD < 4103 && CHROME_VERSION_BUILD >= 3683
+#if CHROME_VERSION_BUILD < 4103
 void BrowserSource::ClearAudioStreams()
 {
 	QueueCEFTask([this]() {
@@ -539,7 +531,7 @@ void BrowserSource::Update(obs_data_t *settings)
 
 	DestroyBrowser(true);
 	DestroyTextures();
-#if CHROME_VERSION_BUILD < 4103 && CHROME_VERSION_BUILD >= 3683
+#if CHROME_VERSION_BUILD < 4103
 	ClearAudioStreams();
 #endif
 	if (!shutdown_on_invisible || obs_source_showing(source))

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -26,7 +26,7 @@
 #include <functional>
 #include <string>
 
-#if CHROME_VERSION_BUILD < 4103 && CHROME_VERSION_BUILD >= 3683
+#if CHROME_VERSION_BUILD < 4103
 #include <obs.hpp>
 #include <unordered_map>
 #include <vector>
@@ -110,7 +110,7 @@ struct BrowserSource {
 	void Update(obs_data_t *settings = nullptr);
 	void Tick();
 	void Render();
-#if CHROME_VERSION_BUILD < 4103 && CHROME_VERSION_BUILD >= 3683
+#if CHROME_VERSION_BUILD < 4103
 	void ClearAudioStreams();
 	void EnumAudioStreams(obs_source_enum_proc_t cb, void *param);
 	bool AudioMix(uint64_t *ts_out, struct audio_output_data *audio_output,

--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -160,10 +160,7 @@ bool QCefBrowserClient::OnBeforePopup(
 	const CefString &, CefLifeSpanHandler::WindowOpenDisposition, bool,
 	const CefPopupFeatures &, CefWindowInfo &windowInfo,
 	CefRefPtr<CefClient> &, CefBrowserSettings &,
-#if CHROME_VERSION_BUILD >= 3770
-	CefRefPtr<CefDictionaryValue> &,
-#endif
-	bool *)
+	CefRefPtr<CefDictionaryValue> &, bool *)
 {
 	if (allowAllPopups) {
 #ifdef _WIN32

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -63,9 +63,7 @@ public:
 		bool user_gesture, const CefPopupFeatures &popupFeatures,
 		CefWindowInfo &windowInfo, CefRefPtr<CefClient> &client,
 		CefBrowserSettings &settings,
-#if CHROME_VERSION_BUILD >= 3770
 		CefRefPtr<CefDictionaryValue> &extra_info,
-#endif
 		bool *no_javascript_access) override;
 
 	/* CefContextMenuHandler */

--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -24,24 +24,6 @@ extern std::vector<PopupWhitelistInfo> forced_popups;
 
 /* ------------------------------------------------------------------------- */
 
-#if CHROME_VERSION_BUILD < 3770
-class QCefRequestContextHandler : public CefRequestContextHandler {
-	CefRefPtr<CefCookieManager> cm;
-
-public:
-	inline QCefRequestContextHandler(CefRefPtr<CefCookieManager> cm_)
-		: cm(cm_)
-	{
-	}
-
-	virtual CefRefPtr<CefCookieManager> GetCookieManager() override;
-
-	IMPLEMENT_REFCOUNTING(QCefRequestContextHandler);
-};
-#endif
-
-/* ------------------------------------------------------------------------- */
-
 class QCefWidgetInternal : public QCefWidget {
 	Q_OBJECT
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes ifdefs that only benefit anyone using a CEF version older than 3770.
Since 3770 is the oldest version of CEF supported and shipped, their content was dead code.

This dead code got removed, none of the current functionality on any CEF >= 3770 should be effected.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stumbled across some of them while working on something else, and noticed they weren't needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled on macOS.
This did require me to rebuild the cmake project and clear Xcode caches since Xcode has some scripts that assumed the removed header was still there, but that isn't project-related.

I unfortunately can't test Windows. 


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
