### PR TITLE
Manually unset XdndProxy ("Stop deleting dragged items, browser panel, pretty please")

### DIFF
--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -73,6 +73,12 @@ public:
 
 	void Resize();
 
+#ifdef __linux__
+private:
+	bool needsDeleteXdndProxy = true;
+	void unsetToplevelXdndProxy();
+#endif
+
 public slots:
 	void Init();
 };


### PR DESCRIPTION
### Description

The explanation for this issue, and the subsequent fix I hereby propose, is long, too long. For that, my apologies.

When a browser panel is created on an X11 environment, it does so passing a CefWindowInfo set up through `windowInfo.SetAsChild(windowId, rect)`. CEF then creates an X11 Window that is child of this `windowId` to render into. In addition to that, when the CEF window is shown, it walks up the window tree, and [sets the XdndProxy atom of the topmost window to its own render X11 window](https://bitbucket.org/chromiumembedded/cef/src/1ffa5528b3e3640751e19cf47d8bcb615151907b/libcef/browser/native/window_x11.cc#lines-187:207). CEF does so to sneakily steal drag events from the toplevel.

However, this behavior is problematic for OBS Studio.

When OBS Studio has custom browser panels added and visible, and these panels are attached to the main window, the CEF widgetry is created and added to the main window. CEF then happily walks up the window tree, and sets the XdndProxy property of OBS Studio's main window.

This behavior is innocuous when the browser panel is in a detached dock, since CEF will set the XdndProxy atom of the dock window instead of OBS Studio's main window. CEF is also not aware of the dock window being attached to the main window, and won't try and reset the XdndProxy atom when it happens.

Having the XdndProxy atom set in the main window is the root of all evil we've seen so far. That's because when this atom is set, the [`xdndProxy()` function in QXcbDrag reads the proxy window](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbdrag.cpp?h=v5.15.2#n78) from OBS Studio's main window, and returns it. This function normally returns 0.

In particular, when `xdndProxy()` is called inside [`QXcbDrag::move()`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbdrag.cpp?h=v5.15.2#n413) and returns a non-zero value, the [`if (!proxy_target)` condition right after it](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbdrag.cpp?h=v5.15.2#n414) isn't hit, making Qt use the CEF window as a drag proxy. The CEF window is then [propagated to the `current_proxy_target` class member](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbdrag.cpp?h=v5.15.2#n435).

Then, when releasing the dragged item, `QXcbDrag::drop()` is called, and [tries to find its own internal representation of the `current_proxy_target` window](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbdrag.cpp?h=v5.15.2#n543), which at this point is set to CEF's window - which Qt5 knows nothing about, and thus returns nullptr. This ends up skipping calling `QXcbDrag::handleDrop()` for OBS Studio's main window, sending the dragged item into the void, never to be seen again. Sorry about this terrible fate, dragged item 😢

Fix this whole mess by manually inspecting the toplevel window after setting up each CEF browser, and deleting the XdndProxy atom if it exists.

Fixes obsproject/obs-studio#4488

### Motivation and Context

obsproject/obs-studio#4488

### How Has This Been Tested?

Just try and reproduce obsproject/obs-studio#4488 - it shouldn't be reproducible anymore with this PR.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
