### PR TITLE
`web_security` flag was removed from cef 91

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -177,12 +177,15 @@ bool BrowserSource::CreateBrowser()
 		cefBrowserSettings.default_font_size = 16;
 		cefBrowserSettings.default_fixed_font_size = 16;
 
+#if CHROME_VERSION_BUILD < 4430
 #if ENABLE_LOCAL_FILE_URL_SCHEME
 		if (is_local) {
 			/* Disable web security for file:// URLs to allow
-			 * local content access to remote APIs */
+			 * local content access to remote APIs
+			 * This flag was removed from CEF >= 91 */
 			cefBrowserSettings.web_security = STATE_DISABLED;
 		}
+#endif
 #endif
 
 		cefBrowser = CefBrowserHost::CreateBrowserSync(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
`CefBrowserSettings.web_security` no longer exists from CEF >= 91. This patch adds a version check and removes reference to this flag.

### Motivation and Context
As suggested in the [upstream issue](https://bitbucket.org/chromiumembedded/cef/issues/3058/remove-cefbrowsersettingsweb_security), the `web_security` flag is considered no longer useful and removed. This change breaks build of current plugin (#305).

### How Has This Been Tested?
I build and test on my own working machine with Gentoo Linux and `master` branch `obs-studio` code. The plugin builds and works fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
