### PR TITLE
browser-panel: Document code introduced by previous commit

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -255,6 +255,13 @@ static bool XWindowHasAtom(Display *display, Window w, Atom a)
 	return type != None;
 }
 
+/* On Linux / X11, CEF sets the XdndProxy of the toplevel window
+ * it's attached to, so that it can read drag events. When this
+ * toplevel happens to be OBS Studio's main window (e.g. when a
+ * browser panel is docked into to the main window), setting the
+ * XdndProxy atom ends up breaking DnD of sources and scenes. Thus,
+ * we have to manually unset this atom.
+ */
 void QCefWidgetInternal::unsetToplevelXdndProxy()
 {
 	if (!cefBrowser)


### PR DESCRIPTION
### Description

Comment the code introduced by https://github.com/obsproject/obs-browser/pull/304.

### Motivation and Context

This was requested by @WizardCM, but https://github.com/obsproject/obs-browser/pull/304 landed before it was addressed.

### How Has This Been Tested?

 - Read the comment
 - Your mind is well functioning
 - You don't feel the urge to read the commit message of c5ba29f66b

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
