### PR TITLE
obs-browser: Groundwork to enable Chrome 4430/arm64/Apple silicon

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -77,10 +77,9 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 	const CefString &, CefRefPtr<CefCommandLine> command_line)
 {
 	if (!shared_texture_available) {
-		bool enableGPU = command_line->HasSwitch("enable-gpu");
 		CefString type = command_line->GetSwitchValue("type");
 
-		if (!enableGPU && type.empty()) {
+		if (!gpuCompositing && type.empty()) {
 			command_line->AppendSwitch("disable-gpu-compositing");
 		}
 	}

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -75,12 +75,15 @@ class BrowserApp : public CefApp,
 	typedef std::map<int, CefRefPtr<CefV8Value>> CallbackMap;
 
 	bool shared_texture_available;
+	bool gpuCompositing;
 	CallbackMap callbackMap;
 	int callbackId;
 
 public:
-	inline BrowserApp(bool shared_texture_available_ = false)
-		: shared_texture_available(shared_texture_available_)
+	inline BrowserApp(bool shared_texture_available_ = false,
+			  bool gpuCompositing_ = true)
+		: shared_texture_available(shared_texture_available_),
+		  gpuCompositing(gpuCompositing_)
 	{
 	}
 

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -69,6 +69,7 @@ static int adapterCount = 0;
 static std::wstring deviceId;
 
 bool hwaccel = false;
+bool gpuCompositing = true;
 
 /* ========================================================================= */
 
@@ -350,7 +351,7 @@ static void BrowserInit(void)
 	}
 #endif
 
-	app = new BrowserApp(tex_sharing_avail);
+	app = new BrowserApp(tex_sharing_avail, gpuCompositing);
 
 #ifdef _WIN32
 	CefExecuteProcess(args, app, nullptr);
@@ -693,7 +694,7 @@ bool obs_module_load(void)
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
 	obs_data_t *private_data = obs_get_private_data();
-	hwaccel = obs_data_get_bool(private_data, "BrowserHWAccel");
+	gpuCompositing = hwaccel = obs_data_get_bool(private_data, "BrowserHWAccel");
 
 	if (hwaccel) {
 		check_hwaccel_support();

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -299,7 +299,7 @@ static void BrowserInit(void)
 	prod_ver << std::to_string(obs_maj) << "." << std::to_string(obs_min)
 		 << "." << std::to_string(obs_pat);
 
-#if CHROME_VERSION_BUILD >= 4472
+#if CHROME_VERSION_BUILD >= 4430
 	CefString(&settings.user_agent_product) = prod_ver.str();
 #else
 	CefString(&settings.product_version) = prod_ver.str();
@@ -694,7 +694,8 @@ bool obs_module_load(void)
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
 	obs_data_t *private_data = obs_get_private_data();
-	gpuCompositing = hwaccel = obs_data_get_bool(private_data, "BrowserHWAccel");
+	gpuCompositing = hwaccel =
+		obs_data_get_bool(private_data, "BrowserHWAccel");
 
 	if (hwaccel) {
 		check_hwaccel_support();

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -694,8 +694,8 @@ bool obs_module_load(void)
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
 	obs_data_t *private_data = obs_get_private_data();
-	gpuCompositing = hwaccel =
-		obs_data_get_bool(private_data, "BrowserHWAccel");
+	gpuCompositing = obs_data_get_bool(private_data, "BrowserHWAccel");
+	hwaccel = gpuCompositing;
 
 	if (hwaccel) {
 		check_hwaccel_support();

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -141,7 +141,7 @@ bool BrowserSource::CreateBrowser()
 #endif
 
 		CefRefPtr<BrowserClient> browserClient = new BrowserClient(
-			this, hwaccel && tex_sharing_avail, reroute_audio);
+			this, tex_sharing_avail, reroute_audio);
 
 		CefWindowInfo windowInfo;
 #if CHROME_VERSION_BUILD < 3071
@@ -152,7 +152,7 @@ bool BrowserSource::CreateBrowser()
 		windowInfo.windowless_rendering_enabled = true;
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
-		windowInfo.shared_texture_enabled = hwaccel;
+		windowInfo.shared_texture_enabled = tex_sharing_avail;
 #endif
 
 		CefBrowserSettings cefBrowserSettings;
@@ -550,8 +550,9 @@ void BrowserSource::Render()
 
 	if (texture) {
 #ifdef __APPLE__
+		bool useDefaultRect = hwaccel;
 		gs_effect_t *effect =
-			obs_get_base_effect((hwaccel) ? OBS_EFFECT_DEFAULT_RECT
+			obs_get_base_effect((useDefaultRect) ? OBS_EFFECT_DEFAULT_RECT
 						      : OBS_EFFECT_DEFAULT);
 #else
 		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);


### PR DESCRIPTION
- Update for custom obs texture sharing support used in CEF
Since these CEF patches are not available on any particularly OBS Project repository, instructions are provided here

```
PREFIX=/Users/youruser/Documents/cef-4430
mkdir -p $PREFIX
cd $PREFIX
mkdir cef
cd cef
mkdir automate
mkdir chromium_git
git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
export PATH=$PREFIX/cef/depot_tools/:$PATH
cd automate
curl -O https://bitbucket.org/chromiumembedded/cef/raw/master/tools/automate/automate-git.py
cd ../chromium_git
python ../automate/automate-git.py --download-dir=$PREFIX/cef/chromium_git --depot-tools-dir=$PREFIX/cef/depot_tools --no-distrib --no-build --arm64-build --branch=4430
cd cef 
patch -p1  < viz_osr_d3d_4430.patch
cd ../chromium/src/cef/ 
./cef_create_projects.sh
cd ..
mv out/Release_GN_x64 out/Release_GN_arm64
vim out/Release_GN_arm64/args.gn
**edit** target_cpu="arm64"
ninja -C out/Release_GN_arm64 cef
cd cef/tools 
./make_distrib.sh --ninja-build --minimal --arm64-build
cd ../binary_distrib 
```
This should produce "cef_binary_90.6.7+g19ba721+chromium-90.0.4430.212_macosarm64_minimal.zip" which will be used as a part of the OBS Studio build and will also need these OBS Browser changes.

### Description
When using CEF 4430 or later, we should use the texture sharing/gpu compositing feature that OBS Browser relies on, otherwise behaves like previously

### Motivation and Context
OBS Studio relies on a custom patch to CEF in order to perform certain features in OBS Browser. Until these patches are integrated into an Apple silicon variant of CEF, OBS Studio isn't at feature parity natively on Apple silicon.

### How Has This Been Tested?
Tested on M1 iMac and M1 MBP 
macOS 11.5.1

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
