### PR TITLE
Set window title for web popups using X11 (on Linux)

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -11,6 +11,9 @@
 #ifdef _WIN32
 #include <windows.h>
 #endif
+#if !defined(_WIN32) && !defined(__APPLE__)
+#include <X11/Xlib.h>
+#endif
 
 /* CefClient */
 CefRefPtr<CefLoadHandler> QCefBrowserClient::GetLoadHandler()
@@ -53,10 +56,12 @@ void QCefBrowserClient::OnTitleChange(CefRefPtr<CefBrowser> browser,
 		QMetaObject::invokeMethod(widget, "titleChanged",
 					  Q_ARG(QString, qt_title));
 	} else { /* handle popup title */
+		CefWindowHandle handl = browser->GetHost()->GetWindowHandle();
 #ifdef _WIN32
 		std::wstring str_title = title;
-		HWND hwnd = browser->GetHost()->GetWindowHandle();
-		SetWindowTextW(hwnd, str_title.c_str());
+		SetWindowTextW((HWND)handl, str_title.c_str());
+#elif defined(__linux__)
+		XStoreName(cef_get_xdisplay(), handl, title.ToString().c_str());
 #endif
 	}
 }


### PR DESCRIPTION
### Description

This modifies the window title of a popup generated by a browser embed/panel based on the name of the webpage.

![image](https://user-images.githubusercontent.com/941350/128621029-9e56e8cf-091a-4cde-a88d-bb8e84d6fe4a.png)

I'm PR'ing this to get a second opinion on the implementation because Linux is not my forte and I'd rather not break anything. If no complains come up, I'll merge this in time for 27.1.

### Motivation and Context

Feature parity.

### How Has This Been Tested?

1. Connect a Twitch account and enable FFZ chat integration.
2. In the Chat dock, select the gear, choose "Non-Mod Settings" and then select "FrankerFaceZ Control Center"
3. Notice the new popup now correctly has the title "Twitch" rather than a blank name

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
