### PR TITLE
Premultiplied alpha blend state instead of math

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -29,17 +29,6 @@
 
 using namespace json11;
 
-BrowserClient::~BrowserClient()
-{
-#if defined(SHARED_TEXTURE_SUPPORT_ENABLED) && USE_TEXTURE_COPY
-	if (sharing_available) {
-		obs_enter_graphics();
-		gs_texture_destroy(texture);
-		obs_leave_graphics();
-	}
-#endif
-}
-
 CefRefPtr<CefLoadHandler> BrowserClient::GetLoadHandler()
 {
 	return this;
@@ -275,38 +264,13 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType,
 
 	if (shared_handle != last_handle) {
 		obs_enter_graphics();
-#if USE_TEXTURE_COPY
-		gs_texture_destroy(texture);
-		texture = nullptr;
-#endif
 		gs_texture_destroy(bs->texture);
-		bs->texture = nullptr;
-
-#if USE_TEXTURE_COPY
-		texture = gs_texture_open_shared(
-			(uint32_t)(uintptr_t)shared_handle);
-
-		uint32_t cx = gs_texture_get_width(texture);
-		uint32_t cy = gs_texture_get_height(texture);
-		gs_color_format format = gs_texture_get_color_format(texture);
-
-		bs->texture = gs_texture_create(cx, cy, format, 1, nullptr, 0);
-#else
 		bs->texture = gs_texture_open_shared(
 			(uint32_t)(uintptr_t)shared_handle);
-#endif
 		obs_leave_graphics();
 
 		last_handle = shared_handle;
 	}
-
-#if USE_TEXTURE_COPY
-	if (texture && bs->texture) {
-		obs_enter_graphics();
-		gs_copy_texture(bs->texture, texture);
-		obs_leave_graphics();
-	}
-#endif
 }
 #endif
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -23,8 +23,6 @@
 #include "browser-config.h"
 #include "obs-browser-source.hpp"
 
-#define USE_TEXTURE_COPY 0
-
 struct BrowserSource;
 
 class BrowserClient : public CefClient,
@@ -38,9 +36,6 @@ class BrowserClient : public CefClient,
 		      public CefLoadHandler {
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
-#if USE_TEXTURE_COPY
-	gs_texture_t *texture = nullptr;
-#endif
 #ifdef _WIN32
 	void *last_handle = INVALID_HANDLE_VALUE;
 #elif defined(__APPLE__)
@@ -71,8 +66,6 @@ public:
 		  bs(bs_)
 	{
 	}
-
-	virtual ~BrowserClient();
 
 	/* CefClient */
 	virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override;

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -563,6 +563,16 @@ void BrowserSource::Render()
 		gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 #endif
 
+		bool linear_sample = extra_texture == NULL;
+		gs_texture_t *draw_texture = texture;
+		if (!linear_sample &&
+		    !obs_source_get_texcoords_centered(source)) {
+			gs_copy_texture(extra_texture, texture);
+			draw_texture = extra_texture;
+
+			linear_sample = true;
+		}
+
 		const bool previous = gs_framebuffer_srgb_enabled();
 		gs_enable_framebuffer_srgb(true);
 
@@ -571,12 +581,19 @@ void BrowserSource::Render()
 
 		gs_eparam_t *const image =
 			gs_effect_get_param_by_name(effect, "image");
-		gs_effect_set_texture(image, texture);
+
+		const char *tech;
+		if (linear_sample) {
+			gs_effect_set_texture_srgb(image, draw_texture);
+			tech = "Draw";
+		} else {
+			gs_effect_set_texture(image, draw_texture);
+			tech = "DrawSrgbDecompress";
+		}
 
 		const uint32_t flip_flag = flip ? GS_FLIP_V : 0;
-
-		while (gs_effect_loop(effect, "DrawSrgbDecompress"))
-			gs_draw_sprite(texture, flip_flag, 0, 0);
+		while (gs_effect_loop(effect, tech))
+			gs_draw_sprite(draw_texture, flip_flag, 0, 0);
 
 		gs_blend_state_pop();
 

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -566,15 +566,19 @@ void BrowserSource::Render()
 		const bool previous = gs_framebuffer_srgb_enabled();
 		gs_enable_framebuffer_srgb(true);
 
+		gs_blend_state_push();
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+
 		gs_eparam_t *const image =
 			gs_effect_get_param_by_name(effect, "image");
 		gs_effect_set_texture(image, texture);
 
 		const uint32_t flip_flag = flip ? GS_FLIP_V : 0;
 
-		while (gs_effect_loop(effect,
-				      "DrawSrgbDecompressPremultiplied"))
+		while (gs_effect_loop(effect, "DrawSrgbDecompress"))
 			gs_draw_sprite(texture, flip_flag, 0, 0);
+
+		gs_blend_state_pop();
 
 		gs_enable_framebuffer_srgb(previous);
 	}

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -64,6 +64,7 @@ struct BrowserSource {
 	std::string url;
 	std::string css;
 	gs_texture_t *texture = nullptr;
+	gs_texture_t *extra_texture = nullptr;
 	int width = 0;
 	int height = 0;
 	bool fps_custom = false;
@@ -83,6 +84,10 @@ struct BrowserSource {
 	{
 		if (texture) {
 			obs_enter_graphics();
+			if (extra_texture) {
+				gs_texture_destroy(extra_texture);
+				extra_texture = nullptr;
+			}
 			gs_texture_destroy(texture);
 			texture = nullptr;
 			obs_leave_graphics();


### PR DESCRIPTION
### Description
This is an attempt to preserve RGB channels to behave like Chrome. This
should work on a black background, but blending against anything else
will be done in linear space, and may not look as expected.

Requires obsproject/obs-studio#5354

### Motivation and Context
People want semi-transparency to work as expected.

### How Has This Been Tested?
WebM video supplied by #5347 seems to look like Chrome in browser source with or without default custom CSS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.