### PR TITLE
Add full support for CEF 4638

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -117,7 +117,8 @@ void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
 {
 	CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
 
-	CefRefPtr<CefV8Value> obsStudioObj = CefV8Value::CreateObject(0, 0);
+	CefRefPtr<CefV8Value> obsStudioObj =
+		CefV8Value::CreateObject(nullptr, nullptr);
 	globalObj->SetValue("obsstudio", obsStudioObj,
 			    V8_PROPERTY_ATTRIBUTE_NONE);
 
@@ -154,7 +155,7 @@ void BrowserApp::ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
 	CefRefPtr<CefV8Value> jsFunction = obsStudioObj->GetValue(functionName);
 
 	if (jsFunction && jsFunction->IsFunction())
-		jsFunction->ExecuteFunction(NULL, arguments);
+		jsFunction->ExecuteFunction(nullptr, arguments);
 
 	context->Exit();
 }
@@ -310,7 +311,7 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 
 		CefRefPtr<CefV8Value> dispatchEvent =
 			globalObj->GetValue("dispatchEvent");
-		dispatchEvent->ExecuteFunction(NULL, arguments);
+		dispatchEvent->ExecuteFunction(nullptr, arguments);
 
 		context->Exit();
 
@@ -340,7 +341,7 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 		args.push_back(retval);
 
 		if (callback)
-			callback->ExecuteFunction(NULL, args);
+			callback->ExecuteFunction(nullptr, args);
 
 		context->Exit();
 

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -81,10 +81,9 @@ CefRefPtr<CefResourceRequestHandler> BrowserClient::GetResourceRequestHandler(
 	return nullptr;
 }
 
-CefResourceRequestHandler::ReturnValue
-BrowserClient::OnBeforeResourceLoad(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-				    CefRefPtr<CefRequest> request OBS_UNUSED,
-				    CefRefPtr<CefCallback>)
+CefResourceRequestHandler::ReturnValue BrowserClient::OnBeforeResourceLoad(
+	CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>, CefRefPtr<CefRequest>,
+	CefRefPtr<CefCallback>)
 {
 	return RV_CONTINUE;
 }
@@ -92,7 +91,7 @@ BrowserClient::OnBeforeResourceLoad(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 
 bool BrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 				  const CefString &, const CefString &,
-				  WindowOpenDisposition, bool,
+				  cef_window_open_disposition_t, bool,
 				  const CefPopupFeatures &, CefWindowInfo &,
 				  CefRefPtr<CefClient> &, CefBrowserSettings &,
 #if CHROME_VERSION_BUILD >= 3770
@@ -298,42 +297,59 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>,
 		return;
 	}
 
-	if (shared_handle != last_handle) {
-		obs_enter_graphics();
+#ifndef _WIN32
+	if (shared_handle == last_handle)
+		return;
+#endif
 
-		if (bs->texture) {
-			if (bs->extra_texture) {
-				gs_texture_destroy(bs->extra_texture);
-				bs->extra_texture = nullptr;
-			}
-			gs_texture_destroy(bs->texture);
-			bs->texture = nullptr;
+	obs_enter_graphics();
+
+	if (bs->texture) {
+		if (bs->extra_texture) {
+			gs_texture_destroy(bs->extra_texture);
+			bs->extra_texture = nullptr;
 		}
+#ifdef _WIN32
+		gs_texture_release_sync(bs->texture, 0);
+#endif
+		gs_texture_destroy(bs->texture);
+#ifdef _WIN32
+		CloseHandle(extra_handle);
+#endif
+		bs->texture = nullptr;
+	}
 
 #if defined(__APPLE__) && CHROME_VERSION_BUILD > 4183
-		bs->texture = gs_texture_create_from_iosurface(
-			(IOSurfaceRef)(uintptr_t)shared_handle);
+	bs->texture = gs_texture_create_from_iosurface(
+		(IOSurfaceRef)(uintptr_t)shared_handle);
+#elif defined(_WIN32) && CHROME_VERSION_BUILD > 4183
+	DuplicateHandle(GetCurrentProcess(), (HANDLE)(uintptr_t)shared_handle,
+			GetCurrentProcess(), &extra_handle, 0, false,
+			DUPLICATE_SAME_ACCESS);
+
+	bs->texture =
+		gs_texture_open_nt_shared((uint32_t)(uintptr_t)shared_handle);
+	gs_texture_acquire_sync(bs->texture, 1, INFINITE);
 #else
-		bs->texture = gs_texture_open_shared(
-			(uint32_t)(uintptr_t)shared_handle);
+	bs->texture =
+		gs_texture_open_shared((uint32_t)(uintptr_t)shared_handle);
 #endif
-		if (bs->texture) {
-			const uint32_t cx = gs_texture_get_width(bs->texture);
-			const uint32_t cy = gs_texture_get_height(bs->texture);
-			const gs_color_format format =
-				gs_texture_get_color_format(bs->texture);
-			const gs_color_format linear_format =
-				gs_generalize_format(format);
-			if (linear_format != format) {
-				bs->extra_texture = gs_texture_create(
-					cx, cy, linear_format, 1, nullptr, 0);
-			}
+
+	if (bs->texture) {
+		const uint32_t cx = gs_texture_get_width(bs->texture);
+		const uint32_t cy = gs_texture_get_height(bs->texture);
+		const gs_color_format format =
+			gs_texture_get_color_format(bs->texture);
+		const gs_color_format linear_format =
+			gs_generalize_format(format);
+		if (linear_format != format) {
+			bs->extra_texture = gs_texture_create(
+				cx, cy, linear_format, 1, nullptr, 0);
 		}
-
-		obs_leave_graphics();
-
-		last_handle = shared_handle;
 	}
+	obs_leave_graphics();
+
+	last_handle = shared_handle;
 }
 #endif
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <graphics/graphics.h>
+#include <util/threading.h>
 #include "cef-headers.hpp"
 #include "browser-config.h"
 #include "obs-browser-source.hpp"
@@ -39,9 +40,10 @@ class BrowserClient : public CefClient,
 #endif
 		      public CefLoadHandler {
 
-#ifdef ENABLE_BROWSER_SHARED_TEXTURE
+#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
 #ifdef _WIN32
 	void *last_handle = INVALID_HANDLE_VALUE;
+	void *extra_handle = INVALID_HANDLE_VALUE;
 #elif defined(__APPLE__)
 	void *last_handle = nullptr;
 #endif
@@ -109,7 +111,7 @@ public:
 	OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 		      const CefString &target_url,
 		      const CefString &target_frame_name,
-		      WindowOpenDisposition target_disposition,
+		      cef_window_open_disposition_t target_disposition,
 		      bool user_gesture, const CefPopupFeatures &popupFeatures,
 		      CefWindowInfo &windowInfo, CefRefPtr<CefClient> &client,
 		      CefBrowserSettings &settings,
@@ -151,7 +153,7 @@ public:
 			     PaintElementType type, const RectList &dirtyRects,
 			     const void *buffer, int width,
 			     int height) override;
-#ifdef ENABLE_BROWSER_SHARED_TEXTURE
+#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
 	virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,
 					PaintElementType type,
 					const RectList &dirtyRects,

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -32,8 +32,8 @@ class BrowserClient : public CefClient,
 		      public CefRequestHandler,
 #if CHROME_VERSION_BUILD >= 4638
 		      public CefResourceRequestHandler,
-		      public CefContextMenuHandler,
 #endif
+		      public CefContextMenuHandler,
 		      public CefRenderHandler,
 #if CHROME_VERSION_BUILD >= 3683
 		      public CefAudioHandler,

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -28,14 +28,18 @@ struct BrowserSource;
 class BrowserClient : public CefClient,
 		      public CefDisplayHandler,
 		      public CefLifeSpanHandler,
+		      public CefRequestHandler,
+#if CHROME_VERSION_BUILD >= 4638
+		      public CefResourceRequestHandler,
 		      public CefContextMenuHandler,
+#endif
 		      public CefRenderHandler,
 #if CHROME_VERSION_BUILD >= 3683
 		      public CefAudioHandler,
 #endif
 		      public CefLoadHandler {
 
-#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
+#ifdef ENABLE_BROWSER_SHARED_TEXTURE
 #ifdef _WIN32
 	void *last_handle = INVALID_HANDLE_VALUE;
 #elif defined(__APPLE__)
@@ -72,6 +76,9 @@ public:
 	virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override;
 	virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() override;
 	virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override;
+#if CHROME_VERSION_BUILD >= 4638
+	virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override;
+#endif
 	virtual CefRefPtr<CefContextMenuHandler>
 	GetContextMenuHandler() override;
 #if CHROME_VERSION_BUILD >= 3683
@@ -110,6 +117,21 @@ public:
 		      CefRefPtr<CefDictionaryValue> &extra_info,
 #endif
 		      bool *no_javascript_access) override;
+#if CHROME_VERSION_BUILD >= 4638
+	/* CefRequestHandler */
+	virtual CefRefPtr<CefResourceRequestHandler> GetResourceRequestHandler(
+		CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+		CefRefPtr<CefRequest> request, bool is_navigation,
+		bool is_download, const CefString &request_initiator,
+		bool &disable_default_handling) override;
+
+	/* CefResourceRequestHandler */
+	virtual CefResourceRequestHandler::ReturnValue
+	OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser,
+			     CefRefPtr<CefFrame> frame,
+			     CefRefPtr<CefRequest> request,
+			     CefRefPtr<CefCallback> callback) override;
+#endif
 
 	/* CefContextMenuHandler */
 	virtual void
@@ -129,7 +151,7 @@ public:
 			     PaintElementType type, const RectList &dirtyRects,
 			     const void *buffer, int width,
 			     int height) override;
-#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
+#ifdef ENABLE_BROWSER_SHARED_TEXTURE
 	virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,
 					PaintElementType type,
 					const RectList &dirtyRects,

--- a/browser-scheme.cpp
+++ b/browser-scheme.cpp
@@ -55,7 +55,11 @@ BrowserSchemeHandlerFactory::Create(CefRefPtr<CefBrowser> browser,
 		CefStreamReader::CreateForFile(path);
 #endif
 
-	return new CefStreamResourceHandler(CefGetMimeType(fileExtension),
-					    stream);
+	if (stream) {
+		return new CefStreamResourceHandler(
+			CefGetMimeType(fileExtension), stream);
+	} else {
+		return nullptr;
+	}
 }
 #endif

--- a/browser-scheme.hpp
+++ b/browser-scheme.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <fstream>
 
-#if CHROME_VERSION_BUILD >= 3440
+#if CHROME_VERSION_BUILD >= 3440 && CHROME_VERSION_BUILD < 4638
 #define ENABLE_LOCAL_FILE_URL_SCHEME 1
 #else
 #define ENABLE_LOCAL_FILE_URL_SCHEME 0

--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -47,8 +47,11 @@
 #endif
 
 #if CHROME_VERSION_BUILD >= 3770
-#define SendBrowserProcessMessage(browser, pid, msg) \
-	browser->GetMainFrame()->SendProcessMessage(pid, msg);
+#define SendBrowserProcessMessage(browser, pid, msg)             \
+	CefRefPtr<CefFrame> mainFrame = browser->GetMainFrame(); \
+	if (mainFrame) {                                         \
+		mainFrame->SendProcessMessage(pid, msg);         \
+	}
 #else
 #define SendBrowserProcessMessage(browser, pid, msg) \
 	browser->SendProcessMessage(pid, msg);

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -164,7 +164,7 @@ bool BrowserSource::CreateBrowser()
 		CefBrowserSettings cefBrowserSettings;
 
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
-#ifdef _WIN32
+#ifdef BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED
 		if (!fps_custom) {
 			windowInfo.external_begin_frame_enabled = true;
 			cefBrowserSettings.windowless_frame_rate = 0;
@@ -389,7 +389,8 @@ void BrowserSource::SetShowing(bool showing)
 			true);
 		Json json = Json::object{{"visible", showing}};
 		DispatchJSEvent("obsSourceVisibleChanged", json.dump(), this);
-#if defined(_WIN32) && defined(SHARED_TEXTURE_SUPPORT_ENABLED)
+#if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED) && \
+	defined(SHARED_TEXTURE_SUPPORT_ENABLED)
 		if (showing && !fps_custom) {
 			reset_frame = false;
 		}
@@ -424,7 +425,7 @@ void BrowserSource::Refresh()
 		true);
 }
 #ifdef SHARED_TEXTURE_SUPPORT_ENABLED
-#ifdef _WIN32
+#ifdef BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED
 inline void BrowserSource::SignalBeginFrame()
 {
 	if (reset_frame) {
@@ -550,10 +551,10 @@ void BrowserSource::Tick()
 	if (create_browser && CreateBrowser())
 		create_browser = false;
 #if defined(SHARED_TEXTURE_SUPPORT_ENABLED)
-#if defined(_WIN32)
+#if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED)
 	if (!fps_custom)
 		reset_frame = true;
-#elif defined(__APPLE__)
+#else
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
 	double video_fps = (double)ovi.fps_num / (double)ovi.fps_den;
@@ -622,7 +623,8 @@ void BrowserSource::Render()
 		gs_enable_framebuffer_srgb(previous);
 	}
 
-#if defined(_WIN32) && defined(SHARED_TEXTURE_SUPPORT_ENABLED)
+#if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED) && \
+	defined(SHARED_TEXTURE_SUPPORT_ENABLED)
 	SignalBeginFrame();
 #elif USE_QT_LOOP
 	ProcessCef();

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -69,6 +69,9 @@ struct BrowserSource {
 	int height = 0;
 	bool fps_custom = false;
 	int fps = 0;
+#ifdef __APPLE__
+	double canvas_fps = 0;
+#endif
 	bool restart = false;
 	bool shutdown_on_invisible = false;
 	bool is_local = false;

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -69,16 +69,15 @@ struct BrowserSource {
 	int height = 0;
 	bool fps_custom = false;
 	int fps = 0;
-#ifdef __APPLE__
 	double canvas_fps = 0;
-#endif
 	bool restart = false;
 	bool shutdown_on_invisible = false;
 	bool is_local = false;
 	bool first_update = true;
 	bool reroute_audio = true;
 	ControlLevel webpage_control_level = DEFAULT_CONTROL_LEVEL;
-#if defined(_WIN32) && defined(SHARED_TEXTURE_SUPPORT_ENABLED)
+#if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED) && \
+	defined(SHARED_TEXTURE_SUPPORT_ENABLED)
 	bool reset_frame = false;
 #endif
 	bool is_showing = false;
@@ -132,7 +131,8 @@ struct BrowserSource {
 	void SetActive(bool active);
 	void Refresh();
 
-#if defined(_WIN32) && defined(SHARED_TEXTURE_SUPPORT_ENABLED)
+#if defined(BROWSER_EXTERNAL_BEGIN_FRAME_ENABLED) && \
+	defined(SHARED_TEXTURE_SUPPORT_ENABLED)
 	inline void SignalBeginFrame();
 #endif
 };

--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -195,10 +195,12 @@ void QCefWidgetInternal::closeBrowser()
 				reinterpret_cast<QCefBrowserClient *>(
 					client.get());
 
+			if (bc) {
+				bc->widget = nullptr;
+			}
+
 			cefBrowser->GetHost()->WasHidden(true);
 			cefBrowser->GetHost()->CloseBrowser(true);
-
-			bc->widget = nullptr;
 		};
 
 		/* So you're probably wondering what's going on here.  If you
@@ -231,6 +233,7 @@ void QCefWidgetInternal::closeBrowser()
 #endif
 
 		destroyBrowser(browser);
+		browser = nullptr;
 		cefBrowser = nullptr;
 	}
 }
@@ -332,7 +335,10 @@ void QCefWidgetInternal::Init()
 
 #ifdef __APPLE__
 			QSize size = this->size();
+#endif
 
+#if CHROME_VERSION_BUILD < 4430
+#ifdef __APPLE__
 			windowInfo.SetAsChild((CefWindowHandle)handle, 0, 0,
 					      size.width(), size.height());
 #else
@@ -342,6 +348,11 @@ void QCefWidgetInternal::Init()
 			CefRect rc = {0, 0, size.width(), size.height()};
 #endif
 			windowInfo.SetAsChild((CefWindowHandle)handle, rc);
+#endif
+#else
+			windowInfo.SetAsChild((CefWindowHandle)handle,
+					      CefRect(0, 0, size.width(),
+						      size.height()));
 #endif
 
 			CefRefPtr<QCefBrowserClient> browserClient =

--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -427,6 +427,9 @@ void QCefWidgetInternal::Resize()
 		changes.height = size.height();
 		XConfigureWindow(xDisplay, (Window)handle,
 				 CWX | CWY | CWHeight | CWWidth, &changes);
+#if CHROME_VERSION_BUILD >= 4638
+		XSync(xDisplay, false);
+#endif
 #endif
 	});
 


### PR DESCRIPTION
### Description
Introduces necessary fixes for compatibility with CEF 4638 due to API changes within CEF.

**Note:** This PR stays a draft for now as we need a proper solution to the upstream changes regarding web security disabling for local file support.

### Motivation and Context
Make obs-browser compatible with CEF 4638 which is required for M1 support.

### How Has This Been Tested?
* Tested on Apple M1 machine

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
