### PR TITLE
Add lock for modify BrowserSource::cefBrowser

### DIFF
--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -59,6 +59,7 @@ struct BrowserSource {
 
 	bool tex_sharing_avail = false;
 	bool create_browser = false;
+	std::recursive_mutex lockBrowser;
 	CefRefPtr<CefBrowser> cefBrowser;
 
 	std::string url;
@@ -135,4 +136,7 @@ struct BrowserSource {
 	defined(SHARED_TEXTURE_SUPPORT_ENABLED)
 	inline void SignalBeginFrame();
 #endif
+
+	void SetBrowser(CefRefPtr<CefBrowser> b);
+	CefRefPtr<CefBrowser> GetBrowser();
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
I meet a crash that caused by threadsafe of BrowserSource::cefBrowser.

_obs_graphics_thread_ is getting this shared-ptr variable in _BrowserSource::ExecuteOnBrowser_. 
While calling virtual _AddRef()_,  app crashed at __purecall()._

Check the CEF main thread, I find code location stay at _BrowserSource::CreateBrowser()_:
_cefBrowser = CefBrowserHost::CreateBrowserSync(...)_

Obviously, while changing cefBrowser, lock is need.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
make sure threadsafe

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
changing url/resolution frequently

### Types of changes
Bug fix (non-breaking change which fixes an issue) 
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
