### PR TITLE
obs-browser: Fix compiler warnings

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -118,16 +118,19 @@ bool BrowserClient::OnProcessMessageReceived(
 		} else if (name == "stopVirtualcam") {
 			obs_frontend_stop_virtualcam();
 		}
+		[[fallthrough]];
 	case ControlLevel::Advanced:
 		if (name == "startReplayBuffer") {
 			obs_frontend_replay_buffer_start();
 		} else if (name == "stopReplayBuffer") {
 			obs_frontend_replay_buffer_stop();
 		}
+		[[fallthrough]];
 	case ControlLevel::Basic:
 		if (name == "saveReplayBuffer") {
 			obs_frontend_replay_buffer_save();
 		}
+		[[fallthrough]];
 	case ControlLevel::ReadOnly:
 		if (name == "getCurrentScene") {
 			OBSSource current_scene =
@@ -158,6 +161,7 @@ bool BrowserClient::OnProcessMessageReceived(
 				{"virtualcam",
 				 obs_frontend_virtualcam_active()}};
 		}
+		[[fallthrough]];
 	case ControlLevel::None:
 		if (name == "getControlLevel") {
 			json = Json((int)webpage_control_level);


### PR DESCRIPTION
### Description
This fixes warnings found with GCC on Linux.

### Motivation and Context
Warnings are annoying.

### How Has This Been Tested?
Compiled to see if warnings went away.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
