### PR TITLE
Improve performance of CEF 4638 browser sources

### DIFF
--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -40,7 +40,7 @@
 #include "include/wrapper/cef_library_loader.h"
 #endif
 
-#if CHROME_VERSION_BUILD < 3507
+#if CHROME_VERSION_BUILD < 3507 || CHROME_VERSION_BUILD >= 4430
 #define ENABLE_WASHIDDEN 1
 #else
 #define ENABLE_WASHIDDEN 0

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -202,6 +202,8 @@ bool BrowserSource::CreateBrowser()
 		if (reroute_audio)
 			cefBrowser->GetHost()->SetAudioMuted(true);
 #endif
+		if (obs_source_showing(source))
+			is_showing = true;
 
 		SendBrowserVisibility(cefBrowser, is_showing);
 	});
@@ -561,7 +563,9 @@ void BrowserSource::Tick()
 
 	if (!fps_custom) {
 		if (!!cefBrowser && canvas_fps != video_fps) {
-			Update();
+			cefBrowser->GetHost()->SetWindowlessFrameRate(
+				video_fps);
+			canvas_fps = video_fps;
 		}
 	}
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change makes it so the previously disabled flag ENABLE_WASHIDDEN is
enabled on CEF versions above and including 4430, and so that the
framerate is updated with a specific method call, rather than done by
recreating the browser.

This is technically a revert of revert commit a668444, but I am unable
to find any information anywhere as to why this revert was done, or what
it was intending to fix.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
In scene collections with a lot of heavy weight browser sources across
several scenes (think marathons or large events), 4638 results in
massive performance losses due to not correctly dealing with the
visibility of sources.

Additionally, FPS changes in OBS currently result in the browser being
completely recreated, which adds a lot of needless load to the program,
especially if a scene collection has a lot of browser sources.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
With a large scene collection containing several many browser sources that are
particularly heavyweight, across several scenes. Before these changes, the test
collection chugged at less than 2FPS as many invisible sources competed for
resources, and after these changes, a steady 60FPS was achieved through out.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
