### PR TITLE
Render JavaScript dialogs using Qt

### DIFF
--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -36,6 +36,7 @@
 #include <include/cef_version.h>
 #include <include/cef_render_process_handler.h>
 #include <include/cef_request_context_handler.h>
+#include <include/cef_jsdialog_handler.h>
 #if defined(__APPLE__) && !defined(BROWSER_LEGACY)
 #include "include/wrapper/cef_library_loader.h"
 #endif

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -18,6 +18,12 @@ WebpageControlLevel.Level.Basic="Basic access to OBS (Save replay buffer, etc.)"
 WebpageControlLevel.Level.Advanced="Advanced access to OBS (Change scenes, Start/Stop replay buffer, etc.)"
 WebpageControlLevel.Level.All="Full access to OBS (Start/Stop streaming without warning, etc.)"
 
+Dialog.Alert="JavaScript Alert"
+Dialog.Confirm="JavaScript Confirm"
+Dialog.Prompt="JavaScript Prompt"
+Dialog.BrowserDock="Browser Dock"
+Dialog.ReceivedFrom="Received from '%1'"
+
 Error.Title="Couldn't load that page!"
 Error.Description="Make sure the address is correct, and that the site isn't having issues."
 Error.Retry="Click here to retry"

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -11,7 +11,8 @@ class QCefBrowserClient : public CefClient,
 			  public CefLifeSpanHandler,
 			  public CefContextMenuHandler,
 			  public CefLoadHandler,
-			  public CefKeyboardHandler {
+			  public CefKeyboardHandler,
+			  public CefJSDialogHandler {
 
 public:
 	inline QCefBrowserClient(QCefWidgetInternal *widget_,
@@ -31,6 +32,7 @@ public:
 	virtual CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() override;
 	virtual CefRefPtr<CefContextMenuHandler>
 	GetContextMenuHandler() override;
+	virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() override;
 
 	/* CefDisplayHandler */
 	virtual void OnTitleChange(CefRefPtr<CefBrowser> browser,
@@ -91,6 +93,15 @@ public:
 				   const CefKeyEvent &event,
 				   CefEventHandle os_event,
 				   bool *is_keyboard_shortcut) override;
+
+	/* CefJSDialogHandler */
+	virtual bool OnJSDialog(CefRefPtr<CefBrowser> browser,
+				const CefString &origin_url,
+				CefJSDialogHandler::JSDialogType dialog_type,
+				const CefString &message_text,
+				const CefString &default_prompt_text,
+				CefRefPtr<CefJSDialogCallback> callback,
+				bool &suppress_message) override;
 
 	QCefWidgetInternal *widget = nullptr;
 	std::string script;


### PR DESCRIPTION
### Description

This replaces the blocking CEF dialog with a non-blocking Qt dialog, ensuring that normal OBS user interaction can continue when a browser dock requests user input. Additionally, the dialog specifies which browser dock it originates from.

HTML is also rendered in plaintext (forcefully for the QInputDialog) to avoid arbitrary styling, while retaining newlines.

Depends on

* [ ] https://github.com/obsproject/obs-studio/pull/5593

**Before:**

![image](https://user-images.githubusercontent.com/941350/144029863-492b9f34-7e5e-4d38-b736-ead56a5ca463.png)

![image](https://user-images.githubusercontent.com/941350/144029882-e0a1c041-9c9c-41ee-a405-e19b8b1d8231.png)

![image](https://user-images.githubusercontent.com/941350/144029922-26a93260-5219-4ab5-b548-809928716090.png)


**After:**

![image](https://user-images.githubusercontent.com/941350/144029498-42cfe2e4-a787-46cd-a2a3-a922947990c5.png)

![image](https://user-images.githubusercontent.com/941350/144029523-bb820693-b25b-40aa-895c-13e9812030d2.png)

![image](https://user-images.githubusercontent.com/941350/144029553-30836b75-cb7b-4b40-b3ea-c6f3ea3075bf.png)


### Motivation and Context

Firstly, and most importantly, we don't want a browser dock to have the power of blocking a user from interacting with OBS.

This also ensures a consistent style with other aspects of OBS instead of a poor imitation of a system dialog.

### How Has This Been Tested?

Create a `.html` document with the following contents, load it in a custom browser dock, and press each of the 3 buttons.

```html
<!DOCTYPE html>
<html>

<head>
  <script>
    function ok(dT, text) {
      console.log("OK", dT, text);
      document.querySelector(`span.${dT}.resp`).innerHTML = text || 'OK';
    }
    function cancel(dT, text) {
      console.log("Cancel", dT, text);
      document.querySelector(`span.${dT}.resp`).innerHTML = text || 'Cancel';
    }
    function triggerAlert() {
      const resp = window.alert("This is an alert <span>Hi</span>");
    }
    function triggerConfirm() {
      const resp = window.confirm("This is a confirm?");
      resp ? ok('confirm') : cancel('confirm');
    }
    function triggerPrompt() {
      const resp = window.prompt("This is a confirm?");
      resp ? ok('prompt', resp) : cancel('prompt', resp);
    }
    /* TODO: Similar test for onbeforeunload */
    /* window.onbeforeunload = function () {} */
  </script>
  <style>
    button {
      margin-bottom: 4px;
      padding: 4px 14px;
    }
  </style>
</head>

<body>
  <div>
    <button onclick="triggerAlert()">Trigger window.alert() with text</button>
  </div>
  <div>
    <button onclick="triggerConfirm()">Trigger window.confirm() with text</button><br>
    <span class="confirm resp">&nbsp;</span>
  </div>
  <div>
    <button onclick="triggerPrompt()">Trigger window.prompt() with text</button><br>
    <span class="prompt resp">&nbsp;</span>
  </div>
</body>

</html>
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
