### PR TITLE
Fix unused-parameter warning from compillation

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -133,6 +133,8 @@ void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
 	if (browserVis.find(id) != browserVis.end()) {
 		SetDocumentVisibility(browser, browserVis[id]);
 	}
+#else
+	UNUSED_PARAMETER(browser);
 #endif
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Related to https://github.com/obsproject/obs-studio/pull/5653

This PR is meant to fix some compilation warnings, ignoring FFmpeg, AJA NT2 deprecation and FTL related ones:
 - obs-browser emits a unused-parameter warning if built with the new CEF

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Less there is warning, the better is. No ?
Yes, I don't like warnings so I tried to fix what I can fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I just build this branch on Arch Linux with the new CEF and  no warning from obs-browser were emitted.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
