### PR TITLE
Manually loop transitions for SetTransition

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -173,8 +173,22 @@ bool BrowserClient::OnProcessMessageReceived(
 		} else if (name == "setCurrentTransition") {
 			const std::string transition_name =
 				input_args->GetString(1).ToString();
-			obs_source_t *transition = obs_get_transition_by_name(
-				transition_name.c_str());
+			obs_frontend_source_list transitions = {};
+			obs_frontend_get_transitions(&transitions);
+
+			obs_source_t *transition = nullptr;
+			for (size_t i = 0; i < transitions.sources.num; i++) {
+				obs_source_t *source =
+					transitions.sources.array[i];
+				if (obs_source_get_name(source) ==
+				    transition_name) {
+					transition = obs_source_get_ref(source);
+					break;
+				}
+			}
+
+			obs_frontend_source_list_free(&transitions);
+
 			if (transition) {
 				obs_frontend_set_current_transition(transition);
 				obs_source_release(transition);


### PR DESCRIPTION
### Description

Manually loop transitions for SetTransition instead of get_transition_by_name, which can return Show/Hide transitions for sources.

### Motivation and Context

This fixes an issue where Show/Hide transitions would be returned.

### How Has This Been Tested?

- Open OBS with Remote Debugging enabled (`--remote-debugging-port=1234`)
- Add a Browser source
- Open http://localhost:1234 and select 'OBS | Browser Source'
- Using the `Console` tab, paste in the below code

```js
obsstudio.setCurrentTransition('Cut')
```

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
