### PR TITLE
Add obs-websocket 5.0.0 integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(obs-browser_HEADERS
 	browser-version.h
 	deps/json11/json11.hpp
 	deps/base64/base64.hpp
+	deps/obs-websocket-api/obs-websocket-api.h
 	deps/wide-string.hpp
 	cef-headers.hpp
 	)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Descriptions for these events can be [found here](https://obsproject.com/docs/re
 * obsVirtualcamStarted
 * obsVirtualcamStopped
 * obsExit
+* [Any custom event emitted via obs-websocket vendor requests]
 
 
 ### Control OBS
@@ -345,6 +346,14 @@ window.obsstudio.onActiveChange = function(active) {
 
 };
 ```
+
+### obs-websocket Vendor
+obs-browser includes integration with obs-websocket's Vendor requests. The vendor name to use is `obs-browser`, and available requests are:
+
+- `emit_event` - Takes `event_name` and ?`event_data` parameters. Emits a custom event to all browser sources. To subscribe to events, see [here](#register-for-event-callbacks)
+  - See [#340](https://github.com/obsproject/obs-browser/pull/340) for example usage.
+
+There are no available vendor events at this time.
 
 ## Building
 

--- a/deps/obs-websocket-api/.clang-format
+++ b/deps/obs-websocket-api/.clang-format
@@ -1,0 +1,3 @@
+Language: Cpp
+SortIncludes: false
+DisableFormat: true

--- a/deps/obs-websocket-api/obs-websocket-api.h
+++ b/deps/obs-websocket-api/obs-websocket-api.h
@@ -1,0 +1,135 @@
+/*
+obs-websocket
+Copyright (C) 2016-2021 Stephane Lepin <stephane.lepin@gmail.com>
+Copyright (C) 2020-2021 Kyle Manning <tt2468@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#ifndef _OBS_WEBSOCKET_API_H
+#define _OBS_WEBSOCKET_API_H
+
+#include <obs.h>
+
+#define OBS_WEBSOCKET_API_VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* obs_websocket_vendor;
+typedef void (*obs_websocket_request_callback_function)(obs_data_t*, obs_data_t*, void*);
+
+struct obs_websocket_request_callback {
+	obs_websocket_request_callback_function callback;
+	void *priv_data;
+};
+
+inline proc_handler_t *ph;
+
+static inline proc_handler_t *obs_websocket_get_ph(void)
+{
+	proc_handler_t *global_ph = obs_get_proc_handler();
+	assert(global_ph != NULL);
+
+	calldata_t cd = {0};
+	if (!proc_handler_call(global_ph, "obs_websocket_api_get_ph", &cd))
+		blog(LOG_DEBUG, "Unable to fetch obs-websocket proc handler object. obs-websocket not installed?");
+	proc_handler_t *ret = (proc_handler_t*)calldata_ptr(&cd, "ph");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+static inline bool obs_websocket_run_simple_proc(obs_websocket_vendor vendor, const char *proc_name, calldata_t *cd)
+{
+	if (!ph || !vendor || !proc_name || !strlen(proc_name) || !cd)
+		return false;
+
+	calldata_set_ptr(cd, "vendor", vendor);
+
+	proc_handler_call(ph, proc_name, cd);
+	return calldata_bool(cd, "success");
+}
+
+// ALWAYS CALL VIA `obs_module_post_load()` CALLBACK!
+// Registers a new "vendor" (Example: obs-ndi)
+static inline obs_websocket_vendor obs_websocket_register_vendor(const char *vendor_name)
+{
+	ph = obs_websocket_get_ph();
+	if (!ph)
+		return NULL;
+
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "name", vendor_name);
+
+	proc_handler_call(ph, "vendor_register", &cd);
+	obs_websocket_vendor ret = calldata_ptr(&cd, "vendor");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Registers a new request for a vendor
+static inline bool obs_websocket_vendor_register_request(obs_websocket_vendor vendor, const char *request_type, obs_websocket_request_callback_function request_callback, void* priv_data)
+{
+	calldata_t cd = {0};
+
+	struct obs_websocket_request_callback cb = {};
+	cb.callback = request_callback;
+	cb.priv_data = priv_data;
+
+	calldata_set_string(&cd, "type", request_type);
+	calldata_set_ptr(&cd, "callback", &cb);
+
+	bool success = obs_websocket_run_simple_proc(vendor, "vendor_request_register", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Unregisters an existing vendor request
+static inline bool obs_websocket_vendor_unregister_request(obs_websocket_vendor vendor, const char *request_type)
+{
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "type", request_type);
+
+	bool success = obs_websocket_run_simple_proc(vendor, "vendor_request_unregister", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Does not affect event_data refcount.
+// Emits an event under the vendor's name
+static inline bool obs_websocket_vendor_emit_event(obs_websocket_vendor vendor, const char *event_name, obs_data_t *event_data)
+{
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "type", event_name);
+	calldata_set_ptr(&cd, "data", (void*)event_data);
+
+	bool success = obs_websocket_run_simple_proc(vendor, "vendor_event_emit", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
### Description
This adds integration into obs-websocket's new plugin API. The vendor name registered is `obs-browser`.

Vendor requests:
- `emit_event` - Takes `event_name` and ?`event_data` parameters. Emits a custom event to all browser sources.

### Motivation and Context
Integration between obs-browser and obs-websocket is a great proof of concept for our API and should serve as a great example for third-party plugin developers.

### How Has This Been Tested?
Tested by sending a request to obs-websocket and listening for the event in a test HTML page.

**Request:**
![image](https://user-images.githubusercontent.com/28720189/147737899-2daea19c-9614-47f5-843e-57e9acdccd51.png)

**Test HTML Page:**
```html
<!DOCTYPE html>

<script type="text/javascript">
  window.addEventListener('obs-websocket-test-event', function(event) {
    console.log(event.detail)
  })
</script>
```

**Result in dev tools:**
![image](https://user-images.githubusercontent.com/28720189/147737945-fb7b9b07-f978-4b96-982b-720226df3987.png)


### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
