### PR TITLE
Log cef version in cmake & fix debug builds for cef >= 4430 on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,10 @@ if(SHARED_TEXTURE_SUPPORT_ENABLED)
     target_compile_definitions(obs-browser PRIVATE SHARED_TEXTURE_SUPPORT_ENABLED)
 endif()
 
+if(WIN32 AND (${CHROME_VERSION_BUILD} GREATER_EQUAL 4430))
+	target_compile_definitions(obs-browser PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+endif()
+
 set_target_properties(obs-browser PROPERTIES FOLDER "plugins/obs-browser")
 
 # ----------------------------------------------------------------------------
@@ -304,6 +308,9 @@ if (WIN32)
 	target_sources(obs-browser-page
 		PRIVATE obs-browser-page.manifest
 	)
+	if (${CHROME_VERSION_BUILD} GREATER_EQUAL 4430)
+		target_compile_definitions(obs-browser-page PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+	endif()
 
 	add_custom_command(TARGET obs-browser POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ if(UNIX AND NOT APPLE)
 	include_directories("${X11_INCLUDE_DIR}")
 endif()
 
+file(READ "${CEF_ROOT_DIR}/include/cef_version.h" ver)
+string(REGEX MATCH "CHROME_VERSION_BUILD ([0-9][0-9][0-9][0-9]+)" _ ${ver})
+set(CHROME_VERSION_BUILD ${CMAKE_MATCH_1})
+message(STATUS "Chromium cef version: ${CHROME_VERSION_BUILD}")
+
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/browser-config.h.in"


### PR DESCRIPTION
### Description
SInce this cef commit [1] (cef >= 4430 on windows), iterator debugging was disabled for cef_sandbox. This prevents debug builds for obs-browser and obs-browser-page projects with MSVC.
The issue does not arise on other platforms.
The 2nd commit adds the correct preprocessor definition allowing building for obs-browser and obs-browser-page projects when not using browser_legacy (I.e. cef 4638+ rather than cef 3770).
The first commit retrieves cef version, which allows a version comparison in the 2nd commit.

[1] https://bitbucket.org/chromiumembedded/cef/commits/f2f0bfbdb5a46be8fe99341abf3aaae744573edc

### Motivation and Context
Motivation: we want to be able to debug obs-browser ...

### How Has This Been Tested?
This has been tested by building obs-studio with obs-browser and obs-browser-page with cef 4638.
It builds fine.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
