### PR TITLE
Fix sources not rendering after hide/show

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -52,6 +52,7 @@ static void SendBrowserVisibility(CefRefPtr<CefBrowser> browser, bool isVisible)
 
 #if ENABLE_WASHIDDEN
 	if (isVisible) {
+		browser->GetHost()->WasResized();
 		browser->GetHost()->WasHidden(false);
 		browser->GetHost()->Invalidate(PET_VIEW);
 	} else {


### PR DESCRIPTION
### Description

Back in 2019 when we updated to CEF 3770, the `WasHidden()` API [was broken](https://bitbucket.org/chromiumembedded/cef/issues/2483/osr-invalidate-does-not-generate-frame). 

Because of this, @zavitax had to write [a custom visibility handler](https://github.com/obsproject/obs-browser/pull/168). This worked well until the update to 4638, where it introduced terrible performance when sources weren't visible, so @VodBox [submitted a PR](https://github.com/obsproject/obs-browser/pull/330) to revert back to using the `WasHidden()` API, as it looked to be fixed.

Unfortunately, it seems the current CEF version has the [same bug as before](https://bitbucket.org/chromiumembedded/cef/issues/2483/osr-invalidate-does-not-generate-frame). Marshall has apparently [merged a fix](https://bitbucket.org/chromiumembedded/cef/pull-requests/409/), but the fix doesn't seem to work in this case.

**However**, the hack that previously didn't work - `HasResized()` - does seem to work now. This PR enables that hack.

In summary:

* pre-3770, we used `WasHidden()` with no issue
* for 3770, `WasHidden()` broke, so we used a custom visibility handler
* for 4638, the custom handler caused a performance regression so we re-enabled `WasHidden()`
* unfortunately, that introduced a bug on show, so now I've written this PR

------

~~Additionally, the PR that introduced 4638 support to obs-browser incorrectly renamed some variables. I need @VodBox and @PatTheMav to confirm whether this should be scoped to `_WIN32` or not.~~

### Motivation and Context

We like browser sources that function correctly & have good performance.

Fixes #342

### How Has This Been Tested?

* Run with or without hardware acceleration, hide source, wait, show source

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
