### PR TITLE
Fix showing stale frames on show

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -382,7 +382,7 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>,
 #endif
 		gs_texture_destroy(bs->texture);
 #ifdef _WIN32
-		CloseHandle(extra_handle);
+		CloseHandle(bs->extra_handle);
 #endif
 		bs->texture = nullptr;
 	}
@@ -392,7 +392,7 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>,
 		(IOSurfaceRef)(uintptr_t)shared_handle);
 #elif defined(_WIN32) && CHROME_VERSION_BUILD > 4183
 	DuplicateHandle(GetCurrentProcess(), (HANDLE)(uintptr_t)shared_handle,
-			GetCurrentProcess(), &extra_handle, 0, false,
+			GetCurrentProcess(), &bs->extra_handle, 0, false,
 			DUPLICATE_SAME_ACCESS);
 
 	bs->texture =
@@ -417,7 +417,7 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>,
 	}
 	obs_leave_graphics();
 
-	last_handle = shared_handle;
+	bs->last_handle = shared_handle;
 }
 #endif
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -38,14 +38,6 @@ class BrowserClient : public CefClient,
 		      public CefAudioHandler,
 		      public CefLoadHandler {
 
-#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
-#ifdef _WIN32
-	void *last_handle = INVALID_HANDLE_VALUE;
-	void *extra_handle = INVALID_HANDLE_VALUE;
-#elif defined(__APPLE__)
-	void *last_handle = nullptr;
-#endif
-#endif
 	bool sharing_available = false;
 	bool reroute_audio = true;
 	ControlLevel webpage_control_level = DEFAULT_CONTROL_LEVEL;

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -420,6 +420,25 @@ void BrowserSource::SetShowing(bool showing)
 #endif
 
 		SendBrowserVisibility(cefBrowser, showing);
+
+		if (showing)
+			return;
+
+		obs_enter_graphics();
+
+		if (hwaccel && texture) {
+#ifdef _WIN32
+			gs_texture_release_sync(texture, 0);
+#endif
+			DestroyTextures();
+#ifdef _WIN32
+			CloseHandle(extra_handle);
+#endif
+		} else {
+			DestroyTextures();
+		}
+
+		obs_leave_graphics();
 	}
 }
 

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -68,6 +68,16 @@ struct BrowserSource {
 	std::string css;
 	gs_texture_t *texture = nullptr;
 	gs_texture_t *extra_texture = nullptr;
+
+#ifdef SHARED_TEXTURE_SUPPORT_ENABLED
+#ifdef _WIN32
+	void *last_handle = INVALID_HANDLE_VALUE;
+	void *extra_handle = INVALID_HANDLE_VALUE;
+#elif defined(__APPLE__)
+	void *last_handle = nullptr;
+#endif
+#endif
+
 	int width = 0;
 	int height = 0;
 	bool fps_custom = false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change aims to prevent stale frames being shown when a browser source is shown again after being hidden.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stale frames should not be shown.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Recording various browser pages being hidden then shown again, and checking that the shown frame doesn't match the frame from being hidden.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
