### PR TITLE
Allow resizing without recreate

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -548,12 +548,30 @@ void BrowserSource::Update(obs_data_t *settings)
 		}
 #endif
 
-		if (n_is_local == is_local && n_width == width &&
-		    n_height == height && n_fps_custom == fps_custom &&
+		if (n_is_local == is_local && n_fps_custom == fps_custom &&
 		    n_fps == fps && n_shutdown == shutdown_on_invisible &&
 		    n_restart == restart && n_css == css && n_url == url &&
 		    n_reroute == reroute_audio &&
 		    n_webpage_control_level == webpage_control_level) {
+
+			if (n_width == width && n_height == height)
+				return;
+
+			width = n_width;
+			height = n_height;
+			ExecuteOnBrowser(
+				[=](CefRefPtr<CefBrowser> cefBrowser) {
+					const CefSize cefSize(width, height);
+					cefBrowser->GetHost()
+						->GetClient()
+						->GetDisplayHandler()
+						->OnAutoResize(cefBrowser,
+							       cefSize);
+					cefBrowser->GetHost()->WasResized();
+					cefBrowser->GetHost()->Invalidate(
+						PET_VIEW);
+				},
+				true);
 			return;
 		}
 


### PR DESCRIPTION
### Description
Allow resizing without recreate
![ezgif-3-63686cee83](https://user-images.githubusercontent.com/5457024/149616977-ef1a1e2b-c8cc-4b14-a162-b212e901a04a.gif)


### Motivation and Context
Resizing a browser source should not destroy and recreate it
This allows animating the size of the browser source.

### How Has This Been Tested?
On windows 64 bit using move value filters

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
