### PR TITLE
Remove CefInitialize hack argument on Windows

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -385,6 +385,10 @@ static void BrowserInit(void)
 
 #ifdef _WIN32
 	CefExecuteProcess(args, app, nullptr);
+#endif
+#if !defined(_WIN32) || (CHROME_VERSION_BUILD > 3770)
+	CefInitialize(args, settings, app, nullptr);
+#else
 	/* Massive (but amazing) hack to prevent chromium from modifying our
 	 * process tokens and permissions, which caused us problems with winrt,
 	 * used with window capture.  Note, the structure internally is just
@@ -393,8 +397,6 @@ static void BrowserInit(void)
 	 * to. */
 	uintptr_t zeroed_memory_lol[32] = {};
 	CefInitialize(args, settings, app, zeroed_memory_lol);
-#else
-	CefInitialize(args, settings, app, nullptr);
 #endif
 #if !ENABLE_LOCAL_FILE_URL_SCHEME
 	/* Register http://absolute/ scheme handler for older


### PR DESCRIPTION
### Description
Newer CEF will behave as desired by passing nullptr.

### Motivation and Context
Hack is brittle, and could regress.

### How Has This Been Tested?
Verified WGC capture works with/without admin on old/new CEF.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.