### PR TITLE
Suppress warnings about std::result_of deprecation

### DIFF
--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -20,7 +20,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100)
+#pragma warning(disable : 4100 4996)
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
### Description
CEF header uses deprecated class, so suppress warning.

### Motivation and Context
Don't like warning spam.

### How Has This Been Tested?
Warnings no longer appear.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.