### PR TITLE
Use auto release refs

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -253,10 +253,9 @@ static void missing_file_callback(void *src, const char *new_path, void *data)
 
 	if (bs) {
 		obs_source_t *source = bs->source;
-		obs_data_t *settings = obs_source_get_settings(source);
+		OBSDataAutoRelease settings = obs_source_get_settings(source);
 		obs_data_set_string(settings, "local_file", new_path);
 		obs_source_update(source, settings);
-		obs_data_release(settings);
 	}
 
 	UNUSED_PARAMETER(data);
@@ -269,7 +268,7 @@ static obs_missing_files_t *browser_source_missingfiles(void *data)
 
 	if (bs) {
 		obs_source_t *source = bs->source;
-		obs_data_t *settings = obs_source_get_settings(source);
+		OBSDataAutoRelease settings = obs_source_get_settings(source);
 
 		bool enabled = obs_data_get_bool(settings, "is_local_file");
 		const char *path = obs_data_get_string(settings, "local_file");
@@ -285,8 +284,6 @@ static obs_missing_files_t *browser_source_missingfiles(void *data)
 				obs_missing_files_add_file(files, file);
 			}
 		}
-
-		obs_data_release(settings);
 	}
 
 	return files;
@@ -596,8 +593,7 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		DispatchJSEvent("obsVirtualcamStopped", "");
 		break;
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED: {
-		OBSSource source = obs_frontend_get_current_scene();
-		obs_source_release(source);
+		OBSSourceAutoRelease source = obs_frontend_get_current_scene();
 
 		if (!source)
 			break;
@@ -734,13 +730,12 @@ bool obs_module_load(void)
 	obs_frontend_add_event_callback(handle_obs_frontend_event, nullptr);
 
 #ifdef ENABLE_BROWSER_SHARED_TEXTURE
-	obs_data_t *private_data = obs_get_private_data();
+	OBSDataAutoRelease private_data = obs_get_private_data();
 	hwaccel = obs_data_get_bool(private_data, "BrowserHWAccel");
 
 	if (hwaccel) {
 		check_hwaccel_support();
 	}
-	obs_data_release(private_data);
 #endif
 
 #if defined(__APPLE__) && CHROME_VERSION_BUILD < 4183

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -34,7 +34,7 @@
 #include <vector>
 
 struct AudioStream {
-	OBSSource source;
+	OBSSourceAutoRelease source;
 	speaker_layout speakers;
 	int channels;
 	int sample_rate;


### PR DESCRIPTION
### Description
This sets the refs in the browser source to be automatically
released.

### Motivation and Context
RAII makes things easier.

### How Has This Been Tested?
Tested by adding browser source/panel and made sure there were no memory leaks/bugs.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
