### PR TITLE
cmake: Fix handling of debug wrapper libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,10 +162,12 @@ if(NOT OS_MACOS OR ENABLE_BROWSER_LEGACY)
   target_compile_features(obs-browser-page PRIVATE cxx_std_17)
 
   if(OS_WINDOWS)
-    target_link_libraries(obs-browser-page PRIVATE optimized CEF::Wrapper)
 
     if(TARGET CEF::Wrapper_Debug)
+      target_link_libraries(obs-browser-page PRIVATE optimized CEF::Wrapper)
       target_link_libraries(obs-browser-page PRIVATE debug CEF::Wrapper_Debug)
+    else()
+      target_link_libraries(obs-browser-page PRIVATE CEF::Wrapper)
     endif()
 
     target_sources(obs-browser-page PRIVATE obs-browser-page.manifest)
@@ -200,11 +202,13 @@ if(OS_WINDOWS)
                            PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
   endif()
 
-  target_link_libraries(obs-browser PRIVATE optimized CEF::Wrapper CEF::Library
-                                            d3d11 dxgi)
+  target_link_libraries(obs-browser PRIVATE CEF::Library d3d11 dxgi)
 
   if(TARGET CEF::Wrapper_Debug)
+    target_link_libraries(obs-browser PRIVATE optimized CEF::Wrapper)
     target_link_libraries(obs-browser PRIVATE debug CEF::Wrapper_Debug)
+  else()
+    target_link_libraries(obs-browser PRIVATE CEF::Wrapper)
   endif()
 
   target_link_options(obs-browser PRIVATE "LINKER:/IGNORE:4099")


### PR DESCRIPTION
### Description
Fix and simplify handling of CEF wrapper libraries in debug build configuration.

### Motivation and Context
Specifying separate targets for debug configuration (as well as using
"debug" and "optimized" keywords) is legacy behavior.

The correct way is to specify `_DEBUG` variants of the imported target
properties, which CMake will pick up automatically if the project is
built with debug configuration.

This commit forward-fixes the update on obs-studio, by still using
the legacy behavior if the legacy target is present.

### How Has This Been Tested?
* Tested only locally, but needs to be tested with obs-studio and a pending PR on the main repo.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
