### PR TITLE
Back up then restore POSIX signal handlers on CefInitialize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ target_sources(
           deps/base64/base64.hpp
           deps/wide-string.cpp
           deps/wide-string.hpp
+          deps/signal-restore.cpp
+          deps/signal-restore.hpp
           deps/obs-websocket-api/obs-websocket-api.h
           ${CMAKE_BINARY_DIR}/config/browser-config.h)
 

--- a/deps/signal-restore.cpp
+++ b/deps/signal-restore.cpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+ Copyright (C) 2022 by Kyle Manning <tt2468@gmail.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#include <signal.h>
+#include <string.h>
+
+#include "signal-restore.hpp"
+
+// Method here borrowed from https://bitbucket.org/chromiumembedded/java-cef/src/master/native/signal_restore_posix.cpp
+
+#ifndef _WIN32
+template<typename T, size_t N> char (&ArraySizeHelper(T (&array)[N]))[N];
+#define arraysize(array) (sizeof(ArraySizeHelper(array)))
+
+const int signals_to_restore[] = {SIGHUP, SIGINT,  SIGQUIT, SIGILL,  SIGABRT,
+				  SIGFPE, SIGSEGV, SIGALRM, SIGTERM, SIGCHLD,
+				  SIGBUS, SIGTRAP, SIGPIPE};
+struct sigaction signal_handlers[arraysize(signals_to_restore)];
+
+void BackupSignalHandlers()
+{
+	struct sigaction sigact;
+	for (unsigned i = 0; i < arraysize(signals_to_restore); ++i) {
+		memset(&sigact, 0, sizeof(sigact));
+		sigaction(signals_to_restore[i], nullptr, &sigact);
+		signal_handlers[i] = sigact;
+	}
+}
+
+void RestoreSignalHandlers()
+{
+	for (unsigned i = 0; i < arraysize(signals_to_restore); ++i) {
+		sigaction(signals_to_restore[i], &signal_handlers[i], nullptr);
+	}
+}
+#endif

--- a/deps/signal-restore.hpp
+++ b/deps/signal-restore.hpp
@@ -1,0 +1,23 @@
+/******************************************************************************
+ Copyright (C) 2022 by Kyle Manning <tt2468@gmail.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+#pragma once
+
+#ifndef _WIN32
+void BackupSignalHandlers();
+void RestoreSignalHandlers();
+#endif

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -43,6 +43,8 @@
 #include <dxgi.h>
 #include <dxgi1_2.h>
 #include <d3d11.h>
+#else
+#include "signal-restore.hpp"
 #endif
 
 #ifdef ENABLE_BROWSER_QT_LOOP
@@ -386,7 +388,12 @@ static void BrowserInit(void)
 #ifdef _WIN32
 	CefExecuteProcess(args, app, nullptr);
 #endif
-#if !defined(_WIN32) || (CHROME_VERSION_BUILD > 3770)
+
+#if !defined(_WIN32)
+	BackupSignalHandlers();
+	CefInitialize(args, settings, app, nullptr);
+	RestoreSignalHandlers();
+#elif (CHROME_VERSION_BUILD > 3770)
 	CefInitialize(args, settings, app, nullptr);
 #else
 	/* Massive (but amazing) hack to prevent chromium from modifying our
@@ -398,6 +405,7 @@ static void BrowserInit(void)
 	uintptr_t zeroed_memory_lol[32] = {};
 	CefInitialize(args, settings, app, zeroed_memory_lol);
 #endif
+
 #if !ENABLE_LOCAL_FILE_URL_SCHEME
 	/* Register http://absolute/ scheme handler for older
 	 * CEF builds which do not support file:// URLs */


### PR DESCRIPTION
### Description
Using this trick from the Java CEF library, we can back up our process's signal handlers then restore them after calling CefInitialize.

### Motivation and Context
CefInitialize likes to wipe all of our precious POSIX signal handlers, leading to an unsafe shutdown if SIGINT is raised and there are browsers running.

### How Has This Been Tested?
Ubuntu 20.04 Desktop

Before:
- `SIGINT` to OBS with no browsers: Safe shutdown
- `SIGINT` to OBS with browsers running: Instant exit (unsafe shutdown)

After:
- `SIGINT` to OBS with browsers running: Safe shutdown

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
