### PR TITLE
Replace type mismatch with range-based for loop

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -268,9 +268,10 @@ bool QCefBrowserClient::RunContextMenu(
 			bool enabled;
 			int type_id;
 
-			for (int i = 0; i < menu_items.size(); i++) {
+			for (const std::tuple<std::string, int, bool, int>
+				     &menu_item : menu_items) {
 				std::tie(name, command_id, enabled, type_id) =
-					menu_items[i];
+					menu_item;
 				switch (type_id) {
 				case MENUITEMTYPE_COMMAND: {
 					QAction *item =


### PR DESCRIPTION
### Description
Eliminates mixing of int and size_t.

### Motivation and Context
Fixes a warning on 32-bit Windows build.

### How Has This Been Tested?
Context menu still seems to work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.