### PR TITLE
Avoid redefining UNUSED_PARAMETER rather than linking to libobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ if(NOT OS_MACOS OR ENABLE_BROWSER_LEGACY)
             browser-app.cpp browser-app.hpp deps/json11/json11.cpp
             deps/json11/json11.hpp)
 
-  target_link_libraries(obs-browser-page PRIVATE OBS::libobs CEF::Library)
+  target_link_libraries(obs-browser-page PRIVATE CEF::Library)
 
   target_include_directories(
     obs-browser-page
@@ -271,7 +271,7 @@ elseif(OS_MACOS)
               obs-browser-page/obs-browser-page-main.cpp cef-headers.hpp
               deps/json11/json11.cpp deps/json11/json11.hpp)
 
-    target_link_libraries(${_HELPER_TARGET} PRIVATE OBS::libobs CEF::Wrapper)
+    target_link_libraries(${_HELPER_TARGET} PRIVATE CEF::Wrapper)
 
     target_include_directories(
       ${_HELPER_TARGET}

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -18,7 +18,6 @@
 
 #include "browser-app.hpp"
 #include "browser-version.h"
-#include <util/base.h>
 #include <json11/json11.hpp>
 
 #ifdef _WIN32
@@ -26,10 +25,16 @@
 #endif
 
 #ifdef ENABLE_BROWSER_QT_LOOP
+#include <util/base.h>
 #include <util/platform.h>
 #include <util/threading.h>
 #include <QTimer>
 #endif
+
+#define UNUSED_PARAMETER(x) \
+	{                   \
+		(void)x;    \
+	}
 
 using namespace json11;
 

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -31,10 +31,12 @@
 #include <QTimer>
 #endif
 
+#ifndef UNUSED_PARAMETER
 #define UNUSED_PARAMETER(x) \
 	{                   \
 		(void)x;    \
 	}
+#endif
 
 using namespace json11;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

#368 links some binary to libobs which is something that should not be done.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm actually working on a PR to treat warnings as errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

The warning/error no longer appear while building OBS Studio with this PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
