### PR TITLE
cmake: Remove setting code sign identity for Xcode builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,6 @@ elseif(OS_MACOS)
         FOLDER "plugins/obs-browser/helpers/"
         XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER
         "com.obsproject.obs-studio.helper${_PLIST_SUFFIX}"
-        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "${OBS_BUNDLE_CODESIGN_IDENTITY}"
         XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
         "${CMAKE_SOURCE_DIR}/cmake/bundle/macOS/entitlements-helper${_PLIST_SUFFIX}.plist"
     )


### PR DESCRIPTION
### Description
This is a companion commit to fix the team-based code signing in Xcode enabled by https://github.com/obsproject/obs-studio/pull/6934

### Motivation and Context
Using a team identifier with automatic code signing allows development teams to use stable code signatures without requiring each member to have their own Apple Developer membership.

### How Has This Been Tested?
Tested on macOS 12.5.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
