### PR TITLE
Null check macOS window handle before detaching view

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -197,9 +197,10 @@ void QCefWidgetInternal::closeBrowser()
 		}
 #elif __APPLE__
 		// felt hacky, might delete later
-		id view = (id)cefBrowser->GetHost()->GetWindowHandle();
-		((void (*)(id, SEL))objc_msgSend)(
-			view, sel_getUid("removeFromSuperview"));
+		void *view = (id)cefBrowser->GetHost()->GetWindowHandle();
+		if (*((bool *)view))
+			((void (*)(id, SEL))objc_msgSend)(
+				(id)view, sel_getUid("removeFromSuperview"));
 #endif
 
 		destroyBrowser(browser);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a crash with service integrations.
What the original code does is decoupling the browser from the widget (more explanation is in the comment a few lines above the modified). For some reason however, on Qt 6 the window handle can be null sometimes. In that case, trying to detach the view from the view from the superview fails (obviously).

By the way, the code looks cursed for two reasons:
1) It's Objective-C in a C(++) file
2) It was unreadable even before. If desired I can untangle the original code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want crashes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.
No more crashes with Twitch integration.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
