### PR TITLE
Add ability to mute individual browser docks/panels

### DIFF
--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -89,6 +89,11 @@ public:
 		       CefRefPtr<CefRunContextMenuCallback> callback) override;
 #endif
 
+	virtual bool OnContextMenuCommand(
+		CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+		CefRefPtr<CefContextMenuParams> params, int command_id,
+		CefContextMenuHandler::EventFlags event_flags) override;
+
 	/* CefLoadHandler */
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,
 			       CefRefPtr<CefFrame> frame,


### PR DESCRIPTION

### Description

Adds a new menu item to the context menu of browser docks, allowing the user to mute the current dock. Does not persist across sessions.

![image](https://user-images.githubusercontent.com/941350/196032613-d13b42cd-507f-43ba-8e63-0c64c2a3f597.png)


### Motivation and Context

Requested at https://ideas.obsproject.com/posts/1984/allow-audio-control-of-browser-docks

The contents of a browser dock are often provided by a third party, and may not have full controls, such as the ability to mute ads or other third party content.

Additionally, adding support for custom context menu items will allow for other options such as opening the Dev Tools to improve the developer & troubleshooting experience when working with custom docks.

### How Has This Been Tested?

Windows 10, right click a browser dock playing a YouTube video and click Mute. Do the same to unmute.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
