### PR TITLE
Add proc handler for javascript event

### DIFF
--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -87,6 +87,22 @@ BrowserSource::BrowserSource(obs_data_t *, obs_source_t *source_)
 				   obs_module_text("RefreshNoCache"),
 				   refreshFunction, (void *)this);
 
+	auto jsEventFunction = [](void *p, calldata_t *calldata) {
+		const auto eventName = calldata_string(calldata, "eventName");
+		if (!eventName)
+			return;
+		auto jsonString = calldata_string(calldata, "jsonString");
+		if (!jsonString)
+			jsonString = "null";
+		DispatchJSEvent(eventName, jsonString, (BrowserSource *)p);
+	};
+
+	proc_handler_t *ph = obs_source_get_proc_handler(source);
+	proc_handler_add(
+		ph,
+		"void javascript_event(string eventName, string jsonString)",
+		jsEventFunction, (void *)this);
+
 	/* defer update */
 	obs_source_update(source, nullptr);
 


### PR DESCRIPTION
### Description
Add proc handler for javascript event to a browser source

### Motivation and Context
Allow other plugins to use javascript events on browser sources.
This can be used by the Browser Transition plugin to send start transition event including duration

### How Has This Been Tested?
With test code in the Browser Transition plugin

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
