### PR TITLE
Fix issues with failed JSON parsing in JS API responses

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -243,6 +243,56 @@ void BrowserApp::SetDocumentVisibility(CefRefPtr<CefBrowser> browser,
 }
 #endif
 
+CefRefPtr<CefV8Value> CefValueToCefV8Value(CefRefPtr<CefValue> value)
+{
+	CefRefPtr<CefV8Value> result;
+	switch (value->GetType()) {
+	case VTYPE_INVALID:
+		result = CefV8Value::CreateNull();
+		break;
+	case VTYPE_NULL:
+		result = CefV8Value::CreateNull();
+		break;
+	case VTYPE_BOOL:
+		result = CefV8Value::CreateBool(value->GetBool());
+		break;
+	case VTYPE_INT:
+		result = CefV8Value::CreateInt(value->GetInt());
+		break;
+	case VTYPE_DOUBLE:
+		result = CefV8Value::CreateDouble(value->GetDouble());
+		break;
+	case VTYPE_STRING:
+		result = CefV8Value::CreateString(value->GetString());
+		break;
+	case VTYPE_BINARY:
+		result = CefV8Value::CreateNull();
+		break;
+	case VTYPE_DICTIONARY: {
+		result = CefV8Value::CreateObject(nullptr, nullptr);
+		CefRefPtr<CefDictionaryValue> dict = value->GetDictionary();
+		CefDictionaryValue::KeyList keys;
+		dict->GetKeys(keys);
+		for (unsigned int i = 0; i < keys.size(); i++) {
+			CefString key = keys[i];
+			result->SetValue(
+				key, CefValueToCefV8Value(dict->GetValue(key)),
+				V8_PROPERTY_ATTRIBUTE_NONE);
+		}
+	} break;
+	case VTYPE_LIST: {
+		CefRefPtr<CefListValue> list = value->GetList();
+		size_t size = list->GetSize();
+		result = CefV8Value::CreateArray((int)size);
+		for (int i = 0; i < size; i++) {
+			result->SetValue(
+				i, CefValueToCefV8Value(list->GetValue(i)));
+		}
+	} break;
+	}
+	return result;
+}
+
 bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 					  CefRefPtr<CefFrame> frame,
 					  CefProcessId source_process,
@@ -312,8 +362,6 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 	} else if (message->GetName() == "executeCallback") {
 		CefRefPtr<CefV8Context> context =
 			browser->GetMainFrame()->GetV8Context();
-		CefRefPtr<CefV8Value> retval;
-		CefRefPtr<CefV8Exception> exception;
 
 		context->Enter();
 
@@ -321,16 +369,13 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 		int callbackID = arguments->GetInt(0);
 		CefString jsonString = arguments->GetString(1);
 
-		std::string script;
-		script += "JSON.parse('";
-		script += arguments->GetString(1).ToString();
-		script += "');";
+		CefRefPtr<CefValue> json =
+			CefParseJSON(arguments->GetString(1).ToString(), {});
 
 		CefRefPtr<CefV8Value> callback = callbackMap[callbackID];
 		CefV8ValueList args;
 
-		context->Eval(script, browser->GetMainFrame()->GetURL(), 0,
-			      retval, exception);
+		CefRefPtr<CefV8Value> retval = CefValueToCefV8Value(json);
 
 		args.push_back(retval);
 

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -204,7 +204,7 @@ bool BrowserClient::OnProcessMessageReceived(
 		if (name == "getScenes") {
 			struct obs_frontend_source_list list = {};
 			obs_frontend_get_scenes(&list);
-			std::vector<const char *> scenes_vector;
+			std::vector<nlohmann::json> scenes_vector;
 			for (size_t i = 0; i < list.sources.num; i++) {
 				obs_source_t *source = list.sources.array[i];
 				scenes_vector.push_back(
@@ -230,7 +230,7 @@ bool BrowserClient::OnProcessMessageReceived(
 		} else if (name == "getTransitions") {
 			struct obs_frontend_source_list list = {};
 			obs_frontend_get_transitions(&list);
-			std::vector<const char *> transitions_vector;
+			std::vector<nlohmann::json> transitions_vector;
 			for (size_t i = 0; i < list.sources.num; i++) {
 				obs_source_t *source = list.sources.array[i];
 				transitions_vector.push_back(


### PR DESCRIPTION
### Description

Using a [forum post](https://magpcss.org/ceforum/viewtopic.php?f=10&t=14807#p33456) as reference, overhauled JSON handling internally to use CefValue rather than the V8 context.

Note: It seems the V8 context is still required in this code block. I am unsure exactly why (it crashes otherwise).

### Motivation and Context

When users call API functions, they expect a response. Especially a valid one. Fixes #390.

### How Has This Been Tested?

`obsstudio.getScenes` and `obsstudio.getCurrentScene` with scene names that contain characters such as `"` and `\`.

Also re-tested all other get functions to make sure nothing else was broken.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
