### PR TITLE
Fix issue with unknown speaker layouts

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -478,12 +478,16 @@ static speaker_layout GetSpeakerLayout(CefAudioHandler::ChannelLayout cefLayout)
 	case CEF_CHANNEL_LAYOUT_STEREO:
 		return SPEAKERS_STEREO; /**< Channels: FL, FR */
 	case CEF_CHANNEL_LAYOUT_2POINT1:
+	case CEF_CHANNEL_LAYOUT_2_1:
+	case CEF_CHANNEL_LAYOUT_SURROUND:
 		return SPEAKERS_2POINT1; /**< Channels: FL, FR, LFE */
 	case CEF_CHANNEL_LAYOUT_2_2:
 	case CEF_CHANNEL_LAYOUT_QUAD:
 	case CEF_CHANNEL_LAYOUT_4_0:
 		return SPEAKERS_4POINT0; /**< Channels: FL, FR, FC, RC */
 	case CEF_CHANNEL_LAYOUT_4_1:
+	case CEF_CHANNEL_LAYOUT_5_0:
+	case CEF_CHANNEL_LAYOUT_5_0_BACK:
 		return SPEAKERS_4POINT1; /**< Channels: FL, FR, FC, LFE, RC */
 	case CEF_CHANNEL_LAYOUT_5_1:
 	case CEF_CHANNEL_LAYOUT_5_1_BACK:


### PR DESCRIPTION
### Description
When controlling audio through obs, if audio is set to surround sound (ex: 2.1) ,
sound is not captured if CEF returns a speaker layout which obs treats as unknown.
This solves the issue for several CEF speaker layouts.
The bug was noticed by @notr1ch .

### Motivation and Context
Fix a bug.

### How Has This Been Tested?
Tested that stereo audio from a YouTube video is captured when audio is set to 2.1.
Such a stereo audio is returned by cef as FL FR FC. Previously, the 3 channels were muted.
Now the FL and FR are passed to the 2.1 output.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- 
### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
