### PR TITLE
cmake: Update CMake files for build system 3.0 update

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,13 +1,46 @@
 {
-    "additional_commands": {
-      "find_qt": {
-        "flags": [],
-        "kwargs": {
-          "COMPONENTS": "+",
-          "COMPONENTS_WIN": "+",
-          "COMPONENTS_MACOS": "+",
-          "COMPONENTS_LINUX": "+"
+  "format": {
+    "line_width": 120,
+    "tab_size": 2,
+    "enable_sort": true,
+    "autosort": true
+  },
+  "additional_commands": {
+    "find_qt": {
+      "flags": [],
+      "kwargs": {
+        "COMPONENTS": "+",
+        "COMPONENTS_WIN": "+",
+        "COMPONENTS_MACOS": "+",
+        "COMPONENTS_LINUX": "+"
+      }
+    },
+    "set_target_properties_obs": {
+      "pargs": 1,
+      "flags": [],
+      "kwargs": {
+        "PROPERTIES": {
+          "kwargs": {
+            "PREFIX": 1,
+            "OUTPUT_NAME": 1,
+            "FOLDER": 1,
+            "VERSION": 1,
+            "SOVERSION": 1,
+            "FRAMEWORK": 1,
+            "BUNDLE": 1,
+            "AUTOMOC": 1,
+            "AUTOUIC": 1,
+            "AUTORCC": 1,
+            "AUTOUIC_SEARCH_PATHS": 1,
+            "BUILD_RPATH": 1,
+            "INSTALL_RPATH": 1,
+            "XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC": 1,
+            "XCODE_ATTRIBUTE_CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION": 1,
+            "XCODE_ATTRIBUTE_GCC_WARN_SHADOW":1 ,
+            "LIBRARY_OUTPUT_DIRECTORY": 1
+          }
         }
       }
     }
+  }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,62 +1,23 @@
-project(obs-browser)
+cmake_minimum_required(VERSION 3.16...3.25)
 
-option(
-  ENABLE_BROWSER
-  "Enable building OBS with browser source plugin (required Chromium Embedded Framework)"
-  ${OS_LINUX})
+legacy_check()
 
-if(NOT ENABLE_BROWSER OR NOT ENABLE_UI)
-  message(STATUS "OBS:  DISABLED   obs-browser")
-  message(
-    WARNING
-      "Browser source support is not enabled by default - please switch ENABLE_BROWSER to ON and specify CEF_ROOT_DIR to enable this functionality."
-  )
+option(ENABLE_BROWSER "Enable browser source plugin (required Chromium Embedded Framework)" OFF)
+
+if(NOT ENABLE_BROWSER)
+  target_disable(obs-browser)
+  target_disable_feature(obs-browser "Browser sources are not enabled by default (set CEF_ROOT_DIR and ENABLE_BROWSER)")
+
   return()
 endif()
 
-if(OS_WINDOWS)
-  option(ENABLE_BROWSER_LEGACY
-         "Use legacy CEF version 3770 for browser source plugin" OFF)
-endif()
-
-if(OS_MACOS OR OS_WINDOWS)
-  option(ENABLE_BROWSER_SHARED_TEXTURE
-         "Enable shared texture support for browser source plugin" ON)
-endif()
-
-option(ENABLE_BROWSER_PANELS "Enable Qt web browser panel support" ON)
-option(ENABLE_BROWSER_QT_LOOP
-       "Enable running CEF on the main UI thread alongside Qt" ${OS_MACOS})
-
-mark_as_advanced(ENABLE_BROWSER_LEGACY ENABLE_BROWSER_SHARED_TEXTURE
-                 ENABLE_BROWSER_PANELS ENABLE_BROWSER_QT_LOOP)
-
 find_package(CEF REQUIRED)
-
-if(NOT TARGET CEF::Wrapper)
-  message(
-    FATAL_ERROR
-      "OBS:    -        Unable to find CEF Libraries - set CEF_ROOT_DIR or configure with ENABLE_BROWSER=OFF"
-  )
-endif()
 
 add_library(obs-browser MODULE)
 add_library(OBS::browser ALIAS obs-browser)
 
-if(ENABLE_BROWSER_LEGACY)
-  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_LEGACY)
-endif()
-
-if(ENABLE_BROWSER_SHARED_TEXTURE)
-  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
-endif()
-
-if(ENABLE_BROWSER_QT_LOOP)
-  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_QT_LOOP)
-endif()
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/browser-config.h.in
-               ${CMAKE_BINARY_DIR}/config/browser-config.h)
+option(ENABLE_BROWSER_PANELS "Enable Qt web browser panel support" ON)
+mark_as_advanced(ENABLE_BROWSER_PANELS)
 
 target_sources(
   obs-browser
@@ -80,224 +41,23 @@ target_sources(
           deps/wide-string.hpp
           deps/signal-restore.cpp
           deps/signal-restore.hpp
-          deps/obs-websocket-api/obs-websocket-api.h
-          ${CMAKE_BINARY_DIR}/config/browser-config.h)
+          deps/obs-websocket-api/obs-websocket-api.h)
 
-target_include_directories(obs-browser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/deps
-                                               ${CMAKE_BINARY_DIR}/config)
-
-target_link_libraries(obs-browser PRIVATE OBS::libobs OBS::frontend-api)
+target_include_directories(obs-browser PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps")
 
 target_compile_features(obs-browser PRIVATE cxx_std_17)
-
-if(ENABLE_BROWSER_PANELS OR ENABLE_BROWSER_QT_LOOP)
-  find_qt(COMPONENTS Widgets)
-
-  set_target_properties(
-    obs-browser
-    PROPERTIES AUTOMOC ON
-               AUTOUIC ON
-               AUTORCC ON)
-
-  target_link_libraries(obs-browser PRIVATE Qt::Widgets)
-endif()
-
-if(NOT OS_MACOS OR ENABLE_BROWSER_LEGACY)
-  add_executable(obs-browser-page)
-
-  target_sources(
-    obs-browser-page
-    PRIVATE cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp
-            browser-app.cpp browser-app.hpp deps/json11/json11.cpp
-            deps/json11/json11.hpp)
-
-  target_link_libraries(obs-browser-page PRIVATE CEF::Library)
-
-  target_include_directories(
-    obs-browser-page
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
-            ${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page)
-
-  target_compile_features(obs-browser-page PRIVATE cxx_std_17)
-
-  if(OS_WINDOWS)
-
-    if(TARGET CEF::Wrapper_Debug)
-      target_link_libraries(obs-browser-page PRIVATE optimized CEF::Wrapper)
-      target_link_libraries(obs-browser-page PRIVATE debug CEF::Wrapper_Debug)
-    else()
-      target_link_libraries(obs-browser-page PRIVATE CEF::Wrapper)
-    endif()
-
-    target_sources(obs-browser-page PRIVATE obs-browser-page.manifest)
-  else()
-    target_link_libraries(obs-browser-page PRIVATE CEF::Wrapper)
-  endif()
-
-  if(ENABLE_BROWSER_LEGACY)
-    target_compile_definitions(obs-browser-page PRIVATE ENABLE_BROWSER_LEGACY)
-  endif()
-
-  if(ENABLE_BROWSER_SHARED_TEXTURE)
-    target_compile_definitions(obs-browser-page
-                               PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
-  endif()
-
-  if(ENABLE_BROWSER_QT_LOOP)
-    target_compile_definitions(obs-browser-page PRIVATE ENABLE_BROWSER_QT_LOOP)
-  endif()
-
-  set_target_properties(obs-browser-page PROPERTIES FOLDER
-                                                    "plugins/obs-browser")
-
-  setup_plugin_target(obs-browser-page)
-endif()
+target_link_libraries(obs-browser PRIVATE OBS::libobs OBS::frontend-api)
 
 if(OS_WINDOWS)
-  if(MSVC)
-    target_compile_options(obs-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
-
-    target_compile_options(obs-browser-page
-                           PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
-  endif()
-
-  target_link_libraries(obs-browser PRIVATE CEF::Library d3d11 dxgi)
-
-  if(TARGET CEF::Wrapper_Debug)
-    target_link_libraries(obs-browser PRIVATE optimized CEF::Wrapper)
-    target_link_libraries(obs-browser PRIVATE debug CEF::Wrapper_Debug)
-  else()
-    target_link_libraries(obs-browser PRIVATE CEF::Wrapper)
-  endif()
-
-  target_link_options(obs-browser PRIVATE "LINKER:/IGNORE:4099")
-
-  target_link_options(obs-browser-page PRIVATE "LINKER:/IGNORE:4099"
-                      "LINKER:/SUBSYSTEM:WINDOWS")
-
-  list(APPEND obs-browser_LIBRARIES d3d11 dxgi)
-
+  include(cmake/os-windows.cmake)
 elseif(OS_MACOS)
-  find_library(COREFOUNDATION CoreFoundation)
-  find_library(APPKIT AppKit)
-  mark_as_advanced(COREFOUNDATION APPKIT)
-
-  target_link_libraries(obs-browser PRIVATE ${COREFOUNDATION} ${APPKIT}
-                                            CEF::Wrapper)
-
-  set(CEF_HELPER_TARGET "obs-browser-helper")
-  set(CEF_HELPER_OUTPUT_NAME "OBS Helper")
-  set(CEF_HELPER_APP_SUFFIXES
-      "::" " (GPU):_gpu:.gpu" " (Plugin):_plugin:.plugin"
-      " (Renderer):_renderer:.renderer")
-
-  foreach(_SUFFIXES ${CEF_HELPER_APP_SUFFIXES})
-    string(REPLACE ":" ";" _SUFFIXES ${_SUFFIXES})
-    list(GET _SUFFIXES 0 _NAME_SUFFIX)
-    list(GET _SUFFIXES 1 _TARGET_SUFFIX)
-    list(GET _SUFFIXES 2 _PLIST_SUFFIX)
-
-    set(_HELPER_TARGET "${CEF_HELPER_TARGET}${_TARGET_SUFFIX}")
-    set(_HELPER_OUTPUT_NAME "${CEF_HELPER_OUTPUT_NAME}${_NAME_SUFFIX}")
-
-    set(_HELPER_INFO_PLIST
-        "${CMAKE_CURRENT_BINARY_DIR}/helper-info${_PLIST_SUFFIX}.plist")
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/helper-info.plist" _PLIST_CONTENTS)
-    string(REPLACE "\${EXECUTABLE_NAME}" "${_HELPER_OUTPUT_NAME}"
-                   _PLIST_CONTENTS ${_PLIST_CONTENTS})
-    string(REPLACE "\${PRODUCT_NAME}" "${_HELPER_OUTPUT_NAME}" _PLIST_CONTENTS
-                   ${_PLIST_CONTENTS})
-    string(REPLACE "\${BUNDLE_ID_SUFFIX}" "${_PLIST_SUFFIX}" _PLIST_CONTENTS
-                   ${_PLIST_CONTENTS})
-    string(REPLACE "\${MINIMUM_VERSION}" "${CMAKE_OSX_DEPLOYMENT_TARGET}"
-                   _PLIST_CONTENTS ${_PLIST_CONTENTS})
-    string(REPLACE "\${CURRENT_YEAR}" "${CURRENT_YEAR}" _PLIST_CONTENTS
-                   ${_PLIST_CONTENTS})
-    file(WRITE ${_HELPER_INFO_PLIST} ${_PLIST_CONTENTS})
-
-    set(MACOSX_BUNDLE_GUI_IDENTIFIER
-        "${MACOSX_BUNDLE_GUI_IDENTIFIER}.helper${_PLIST_SUFFIX}")
-
-    add_executable(${_HELPER_TARGET} MACOSX_BUNDLE)
-    add_executable(OBS::browser-helper${_TARGET_SUFFIX} ALIAS ${_HELPER_TARGET})
-    target_sources(
-      ${_HELPER_TARGET}
-      PRIVATE browser-app.cpp browser-app.hpp
-              obs-browser-page/obs-browser-page-main.cpp cef-headers.hpp
-              deps/json11/json11.cpp deps/json11/json11.hpp)
-
-    target_link_libraries(${_HELPER_TARGET} PRIVATE CEF::Wrapper)
-
-    target_include_directories(
-      ${_HELPER_TARGET}
-      PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
-              ${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page)
-
-    target_compile_features(${_HELPER_TARGET} PRIVATE cxx_std_17)
-
-    if(ENABLE_BROWSER_SHARED_TEXTURE)
-      target_compile_definitions(${_HELPER_TARGET}
-                                 PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
-    endif()
-
-    set_target_properties(
-      ${_HELPER_TARGET}
-      PROPERTIES
-        MACOSX_BUNDLE_INFO_PLIST ${_HELPER_INFO_PLIST}
-        OUTPUT_NAME ${_HELPER_OUTPUT_NAME}
-        FOLDER "plugins/obs-browser/helpers/"
-        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER
-        "com.obsproject.obs-studio.helper${_PLIST_SUFFIX}"
-        XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
-        "${CMAKE_SOURCE_DIR}/cmake/bundle/macOS/entitlements-helper${_PLIST_SUFFIX}.plist"
-    )
-  endforeach()
-
-elseif(OS_POSIX)
-  find_package(X11 REQUIRED)
-
-  target_link_libraries(obs-browser PRIVATE CEF::Wrapper CEF::Library X11::X11)
-
-  get_target_property(_CEF_DIRECTORY CEF::Library INTERFACE_LINK_DIRECTORIES)
-
-  set_target_properties(obs-browser PROPERTIES BUILD_RPATH "$ORIGIN/")
-
-  set_target_properties(obs-browser-page PROPERTIES BUILD_RPATH "$ORIGIN/")
-
-  set_target_properties(obs-browser PROPERTIES INSTALL_RPATH "$ORIGIN/")
-  set_target_properties(obs-browser-page PROPERTIES INSTALL_RPATH "$ORIGIN/")
+  include(cmake/os-macos.cmake)
+elseif(OS_LINUX)
+  include(cmake/os-linux.cmake)
 endif()
 
 if(ENABLE_BROWSER_PANELS)
-  add_library(obs-browser-panels INTERFACE)
-  add_library(OBS::browser-panels ALIAS obs-browser-panels)
-  target_sources(
-    obs-browser-panels
-    INTERFACE panel/browser-panel.cpp panel/browser-panel.hpp
-              panel/browser-panel-client.cpp panel/browser-panel-client.hpp
-              panel/browser-panel-internal.hpp)
-
-  target_include_directories(
-    obs-browser-panels INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
-                                 ${CMAKE_CURRENT_SOURCE_DIR}/panel)
-
-  target_link_libraries(obs-browser-panels INTERFACE CEF::Wrapper)
-
-  if(OS_MACOS)
-    target_link_libraries(obs-browser-panels INTERFACE objc)
-  endif()
-
-  target_link_libraries(obs-browser PRIVATE obs-browser-panels)
-
-  target_compile_definitions(obs-browser-panels INTERFACE BROWSER_AVAILABLE)
-
-  if(ENABLE_BROWSER_QT_LOOP)
-    target_compile_definitions(obs-browser-panels
-                               INTERFACE ENABLE_BROWSER_QT_LOOP)
-  endif()
+  include(cmake/feature-panels.cmake)
 endif()
 
-set_target_properties(obs-browser PROPERTIES FOLDER "plugins/obs-browser" PREFIX
-                                                                          "")
-
-setup_plugin_target(obs-browser)
+set_target_properties_obs(obs-browser PROPERTIES FOLDER plugins/obs-browser PREFIX "")

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -21,7 +21,6 @@
 #include <graphics/graphics.h>
 #include <util/threading.h>
 #include "cef-headers.hpp"
-#include "browser-config.h"
 #include "obs-browser-source.hpp"
 
 struct BrowserSource;

--- a/cmake/feature-panels.cmake
+++ b/cmake/feature-panels.cmake
@@ -1,0 +1,21 @@
+find_qt(COMPONENTS Widgets)
+
+add_library(browser-panels INTERFACE)
+add_library(OBS::browser-panels ALIAS browser-panels)
+
+target_sources(browser-panels INTERFACE panel/browser-panel.hpp)
+
+target_include_directories(browser-panels INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/panel")
+
+target_compile_definitions(browser-panels INTERFACE BROWSER_AVAILABLE)
+
+target_sources(obs-browser PRIVATE panel/browser-panel-client.hpp panel/browser-panel-internal.hpp
+                                   panel/browser-panel.cpp panel/browser-panel-client.cpp)
+
+target_link_libraries(obs-browser PRIVATE OBS::browser-panels Qt::Widgets)
+
+set_target_properties(
+  obs-browser
+  PROPERTIES AUTOMOC ON
+             AUTOUIC ON
+             AUTORCC ON)

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -1,0 +1,261 @@
+project(obs-browser)
+
+option(ENABLE_BROWSER "Enable building OBS with browser source plugin (required Chromium Embedded Framework)"
+       ${OS_LINUX})
+
+if(NOT ENABLE_BROWSER OR NOT ENABLE_UI)
+  message(STATUS "OBS:  DISABLED   obs-browser")
+  message(
+    WARNING
+      "Browser source support is not enabled by default - please switch ENABLE_BROWSER to ON and specify CEF_ROOT_DIR to enable this functionality."
+  )
+  return()
+endif()
+
+if(OS_WINDOWS)
+  option(ENABLE_BROWSER_LEGACY "Use legacy CEF version 3770 for browser source plugin" OFF)
+endif()
+
+if(OS_MACOS OR OS_WINDOWS)
+  option(ENABLE_BROWSER_SHARED_TEXTURE "Enable shared texture support for browser source plugin" ON)
+endif()
+
+option(ENABLE_BROWSER_PANELS "Enable Qt web browser panel support" ON)
+option(ENABLE_BROWSER_QT_LOOP "Enable running CEF on the main UI thread alongside Qt" ${OS_MACOS})
+
+mark_as_advanced(ENABLE_BROWSER_LEGACY ENABLE_BROWSER_SHARED_TEXTURE ENABLE_BROWSER_PANELS ENABLE_BROWSER_QT_LOOP)
+
+find_package(CEF REQUIRED)
+
+if(NOT TARGET CEF::Wrapper)
+  message(
+    FATAL_ERROR "OBS:    -        Unable to find CEF Libraries - set CEF_ROOT_DIR or configure with ENABLE_BROWSER=OFF")
+endif()
+
+add_library(obs-browser MODULE)
+add_library(OBS::browser ALIAS obs-browser)
+
+if(ENABLE_BROWSER_LEGACY)
+  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_LEGACY)
+endif()
+
+if(ENABLE_BROWSER_SHARED_TEXTURE)
+  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+endif()
+
+if(ENABLE_BROWSER_QT_LOOP)
+  target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_QT_LOOP)
+endif()
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/browser-config.h.in ${CMAKE_BINARY_DIR}/config/browser-config.h)
+
+target_sources(
+  obs-browser
+  PRIVATE obs-browser-plugin.cpp
+          obs-browser-source.cpp
+          obs-browser-source.hpp
+          obs-browser-source-audio.cpp
+          browser-app.cpp
+          browser-app.hpp
+          browser-client.cpp
+          browser-client.hpp
+          browser-scheme.cpp
+          browser-scheme.hpp
+          browser-version.h
+          cef-headers.hpp
+          deps/json11/json11.cpp
+          deps/json11/json11.hpp
+          deps/base64/base64.cpp
+          deps/base64/base64.hpp
+          deps/wide-string.cpp
+          deps/wide-string.hpp
+          deps/signal-restore.cpp
+          deps/signal-restore.hpp
+          deps/obs-websocket-api/obs-websocket-api.h
+          ${CMAKE_BINARY_DIR}/config/browser-config.h)
+
+target_include_directories(obs-browser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/deps ${CMAKE_BINARY_DIR}/config)
+
+target_link_libraries(obs-browser PRIVATE OBS::libobs OBS::frontend-api)
+
+target_compile_features(obs-browser PRIVATE cxx_std_17)
+
+if(ENABLE_BROWSER_PANELS OR ENABLE_BROWSER_QT_LOOP)
+  find_qt(COMPONENTS Widgets)
+
+  set_target_properties(
+    obs-browser
+    PROPERTIES AUTOMOC ON
+               AUTOUIC ON
+               AUTORCC ON)
+
+  target_link_libraries(obs-browser PRIVATE Qt::Widgets)
+endif()
+
+if(NOT OS_MACOS OR ENABLE_BROWSER_LEGACY)
+  add_executable(obs-browser-page)
+
+  target_sources(obs-browser-page PRIVATE cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp browser-app.cpp
+                                          browser-app.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
+
+  target_link_libraries(obs-browser-page PRIVATE CEF::Library)
+
+  target_include_directories(obs-browser-page PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
+                                                      ${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page)
+
+  target_compile_features(obs-browser-page PRIVATE cxx_std_17)
+
+  if(OS_WINDOWS)
+
+    if(TARGET CEF::Wrapper_Debug)
+      target_link_libraries(obs-browser-page PRIVATE optimized CEF::Wrapper)
+      target_link_libraries(obs-browser-page PRIVATE debug CEF::Wrapper_Debug)
+    else()
+      target_link_libraries(obs-browser-page PRIVATE CEF::Wrapper)
+    endif()
+
+    target_sources(obs-browser-page PRIVATE obs-browser-page.manifest)
+  else()
+    target_link_libraries(obs-browser-page PRIVATE CEF::Wrapper)
+  endif()
+
+  if(ENABLE_BROWSER_LEGACY)
+    target_compile_definitions(obs-browser-page PRIVATE ENABLE_BROWSER_LEGACY)
+  endif()
+
+  if(ENABLE_BROWSER_SHARED_TEXTURE)
+    target_compile_definitions(obs-browser-page PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+  endif()
+
+  if(ENABLE_BROWSER_QT_LOOP)
+    target_compile_definitions(obs-browser-page PRIVATE ENABLE_BROWSER_QT_LOOP)
+  endif()
+
+  set_target_properties(obs-browser-page PROPERTIES FOLDER "plugins/obs-browser")
+
+  setup_plugin_target(obs-browser-page)
+endif()
+
+if(OS_WINDOWS)
+  if(MSVC)
+    target_compile_options(obs-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
+
+    target_compile_options(obs-browser-page PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
+  endif()
+
+  target_link_libraries(obs-browser PRIVATE CEF::Library d3d11 dxgi)
+
+  if(TARGET CEF::Wrapper_Debug)
+    target_link_libraries(obs-browser PRIVATE optimized CEF::Wrapper)
+    target_link_libraries(obs-browser PRIVATE debug CEF::Wrapper_Debug)
+  else()
+    target_link_libraries(obs-browser PRIVATE CEF::Wrapper)
+  endif()
+
+  target_link_options(obs-browser PRIVATE "LINKER:/IGNORE:4099")
+
+  target_link_options(obs-browser-page PRIVATE "LINKER:/IGNORE:4099" "LINKER:/SUBSYSTEM:WINDOWS")
+
+  list(APPEND obs-browser_LIBRARIES d3d11 dxgi)
+
+elseif(OS_MACOS)
+  find_library(COREFOUNDATION CoreFoundation)
+  find_library(APPKIT AppKit)
+  mark_as_advanced(COREFOUNDATION APPKIT)
+
+  target_link_libraries(obs-browser PRIVATE ${COREFOUNDATION} ${APPKIT} CEF::Wrapper)
+
+  target_sources(obs-browser PRIVATE macutil.mm)
+
+  set(CEF_HELPER_TARGET "obs-browser-helper")
+  set(CEF_HELPER_OUTPUT_NAME "OBS Helper")
+  set(CEF_HELPER_APP_SUFFIXES "::" " (GPU):_gpu:.gpu" " (Plugin):_plugin:.plugin" " (Renderer):_renderer:.renderer")
+
+  foreach(_SUFFIXES ${CEF_HELPER_APP_SUFFIXES})
+    string(REPLACE ":" ";" _SUFFIXES ${_SUFFIXES})
+    list(GET _SUFFIXES 0 _NAME_SUFFIX)
+    list(GET _SUFFIXES 1 _TARGET_SUFFIX)
+    list(GET _SUFFIXES 2 _PLIST_SUFFIX)
+
+    set(_HELPER_TARGET "${CEF_HELPER_TARGET}${_TARGET_SUFFIX}")
+    set(_HELPER_OUTPUT_NAME "${CEF_HELPER_OUTPUT_NAME}${_NAME_SUFFIX}")
+
+    set(_HELPER_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/helper-info${_PLIST_SUFFIX}.plist")
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/helper-info.plist" _PLIST_CONTENTS)
+    string(REPLACE "\${EXECUTABLE_NAME}" "${_HELPER_OUTPUT_NAME}" _PLIST_CONTENTS ${_PLIST_CONTENTS})
+    string(REPLACE "\${PRODUCT_NAME}" "${_HELPER_OUTPUT_NAME}" _PLIST_CONTENTS ${_PLIST_CONTENTS})
+    string(REPLACE "\${BUNDLE_ID_SUFFIX}" "${_PLIST_SUFFIX}" _PLIST_CONTENTS ${_PLIST_CONTENTS})
+    string(REPLACE "\${MINIMUM_VERSION}" "${CMAKE_OSX_DEPLOYMENT_TARGET}" _PLIST_CONTENTS ${_PLIST_CONTENTS})
+    string(REPLACE "\${CURRENT_YEAR}" "${CURRENT_YEAR}" _PLIST_CONTENTS ${_PLIST_CONTENTS})
+    file(WRITE ${_HELPER_INFO_PLIST} ${_PLIST_CONTENTS})
+
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "${MACOSX_BUNDLE_GUI_IDENTIFIER}.helper${_PLIST_SUFFIX}")
+
+    add_executable(${_HELPER_TARGET} MACOSX_BUNDLE)
+    add_executable(OBS::browser-helper${_TARGET_SUFFIX} ALIAS ${_HELPER_TARGET})
+    target_sources(${_HELPER_TARGET} PRIVATE browser-app.cpp browser-app.hpp obs-browser-page/obs-browser-page-main.cpp
+                                             cef-headers.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
+
+    target_link_libraries(${_HELPER_TARGET} PRIVATE CEF::Wrapper)
+
+    target_include_directories(${_HELPER_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
+                                                         ${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page)
+
+    target_compile_features(${_HELPER_TARGET} PRIVATE cxx_std_17)
+
+    if(ENABLE_BROWSER_SHARED_TEXTURE)
+      target_compile_definitions(${_HELPER_TARGET} PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+    endif()
+
+    set_target_properties(
+      ${_HELPER_TARGET}
+      PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${_HELPER_INFO_PLIST}
+                 OUTPUT_NAME ${_HELPER_OUTPUT_NAME}
+                 FOLDER "plugins/obs-browser/helpers/"
+                 XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.obsproject.obs-studio.helper${_PLIST_SUFFIX}"
+                 XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
+                 "${CMAKE_SOURCE_DIR}/cmake/bundle/macOS/entitlements-helper${_PLIST_SUFFIX}.plist")
+  endforeach()
+
+elseif(OS_POSIX)
+  find_package(X11 REQUIRED)
+
+  target_link_libraries(obs-browser PRIVATE CEF::Wrapper CEF::Library X11::X11)
+
+  get_target_property(_CEF_DIRECTORY CEF::Library INTERFACE_LINK_DIRECTORIES)
+
+  set_target_properties(obs-browser PROPERTIES BUILD_RPATH "$ORIGIN/")
+
+  set_target_properties(obs-browser-page PROPERTIES BUILD_RPATH "$ORIGIN/")
+
+  set_target_properties(obs-browser PROPERTIES INSTALL_RPATH "$ORIGIN/")
+  set_target_properties(obs-browser-page PROPERTIES INSTALL_RPATH "$ORIGIN/")
+endif()
+
+if(ENABLE_BROWSER_PANELS)
+  add_library(obs-browser-panels INTERFACE)
+  add_library(OBS::browser-panels ALIAS obs-browser-panels)
+  target_sources(
+    obs-browser-panels INTERFACE panel/browser-panel.cpp panel/browser-panel.hpp panel/browser-panel-client.cpp
+                                 panel/browser-panel-client.hpp panel/browser-panel-internal.hpp)
+
+  target_include_directories(obs-browser-panels INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/panel)
+
+  target_link_libraries(obs-browser-panels INTERFACE CEF::Wrapper)
+
+  if(OS_MACOS)
+    target_link_libraries(obs-browser-panels INTERFACE objc)
+  endif()
+
+  target_link_libraries(obs-browser PRIVATE obs-browser-panels)
+
+  target_compile_definitions(obs-browser-panels INTERFACE BROWSER_AVAILABLE)
+
+  if(ENABLE_BROWSER_QT_LOOP)
+    target_compile_definitions(obs-browser-panels INTERFACE ENABLE_BROWSER_QT_LOOP)
+  endif()
+endif()
+
+set_target_properties(obs-browser PROPERTIES FOLDER "plugins/obs-browser" PREFIX "")
+
+setup_plugin_target(obs-browser)

--- a/cmake/macos/Info-helper.plist.in
+++ b/cmake/macos/Info-helper.plist.in
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>${EXECUTABLE_NAME}</string>
+    <key>CFBundleExecutable</key>
+    <string>${EXECUTABLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.obsproject.obs-studio.helper${BUNDLE_ID_SUFFIX}</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${PRODUCT_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSEnvironment</key>
+    <dict>
+        <key>MallocNanoZone</key>
+        <string>0</string>
+    </dict>
+    <key>LSFileQuarantineEnabled</key>
+    <true/>
+    <key>LSMinimumSystemVersion</key>
+    <string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
+    <key>LSUIElement</key>
+    <string>1</string>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>(c) 2012-${CURRENT_YEAR} Hugh Bailey</string>
+</dict>
+</plist>

--- a/cmake/macos/Info.plist.in
+++ b/cmake/macos/Info.plist.in
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>obs-browser</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.obsproject.obs-browser</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>obs-browser</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) 2012-${CURRENT_YEAR} Hugh Bailey</string>
+</dict>
+</plist>

--- a/cmake/macos/entitlements-helper.gpu.plist
+++ b/cmake/macos/entitlements-helper.gpu.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/cmake/macos/entitlements-helper.plist
+++ b/cmake/macos/entitlements-helper.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+   <true/>
+   <key>com.apple.security.cs.disable-library-validation</key>
+   <true/>
+   <key>com.apple.security.cs.allow-jit</key>
+   <true/>
+</dict>
+</plist>

--- a/cmake/macos/entitlements-helper.plugin.plist
+++ b/cmake/macos/entitlements-helper.plugin.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/cmake/macos/entitlements-helper.renderer.plist
+++ b/cmake/macos/entitlements-helper.renderer.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/cmake/os-linux.cmake
+++ b/cmake/os-linux.cmake
@@ -1,0 +1,24 @@
+find_package(X11 REQUIRED)
+
+target_link_libraries(obs-browser PRIVATE CEF::Wrapper CEF::Library X11::X11)
+set_target_properties(obs-browser PROPERTIES BUILD_RPATH "$ORIGIN/" INSTALL_RPATH "$ORIGIN/")
+
+add_executable(browser-helper)
+add_executable(OBS::browser-helper ALIAS browser-helper)
+
+target_sources(browser-helper PRIVATE cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp browser-app.cpp
+                                      browser-app.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
+
+target_include_directories(browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
+                                                  "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")
+
+target_link_libraries(browser-helper PRIVATE CEF::Wrapper CEF::Library)
+
+set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
+set_target_properties_obs(
+  browser-helper
+  PROPERTIES FOLDER plugins/obs-browser
+             BUILD_RPATH "$ORIGIN/"
+             INSTALL_RPATH "$ORIGIN/"
+             PREFIX ""
+             OUTPUT_NAME obs-browser-page)

--- a/cmake/os-macos.cmake
+++ b/cmake/os-macos.cmake
@@ -1,0 +1,54 @@
+find_qt(COMPONENTS Widgets)
+
+find_library(COREFOUNDATION CoreFoundation)
+find_library(APPKIT AppKit)
+mark_as_advanced(COREFOUNDATION APPKIT)
+
+target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE ENABLE_BROWSER_QT_LOOP)
+
+target_link_libraries(obs-browser PRIVATE Qt::Widgets ${COREFOUNDATION} ${APPKIT} CEF::Wrapper)
+
+set(helper_basename browser-helper)
+set(helper_output_name "OBS Helper")
+set(helper_suffixes "::" " (GPU):_gpu:.gpu" " (Plugin):_plugin:.plugin" " (Renderer):_renderer:.renderer")
+
+foreach(helper IN LISTS helper_suffixes)
+  string(REPLACE ":" ";" helper ${helper})
+  list(GET helper 0 helper_name)
+  list(GET helper 1 helper_target)
+  list(GET helper 2 helper_plist)
+
+  set(target_name ${helper_basename}${helper_target})
+  set(target_output_name "${helper_output_name}${helper_name}")
+  set(EXECUTABLE_NAME "${target_output_name}")
+  set(BUNDLE_ID_SUFFIX ${helper_plist})
+
+  configure_file(cmake/macos/Info-helper.plist.in Info-Helper${helper_plist}.plist)
+
+  add_executable(${target_name} MACOSX_BUNDLE EXCLUDE_FROM_ALL)
+  add_executable(OBS::${target_name} ALIAS ${target_name})
+
+  target_sources(${target_name} PRIVATE browser-app.cpp browser-app.hpp obs-browser-page/obs-browser-page-main.cpp
+                                        cef-headers.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
+  target_compile_definitions(${target_name} PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+
+  target_include_directories(${target_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
+                                                    "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")
+
+  target_link_libraries(${target_name} PRIVATE CEF::Wrapper)
+
+  set_target_properties(
+    ${target_name}
+    PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info-Helper${helper_plist}.plist"
+               OUTPUT_NAME "${target_output_name}"
+               FOLDER plugins/obs-browser/helper_suffixes
+               XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.obsproject.obs-studio.helper${helper_plist}
+               XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
+               "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/entitlements-helper${helper_plist}.plist")
+endforeach()
+
+set_target_properties(
+  obs-browser
+  PROPERTIES AUTOMOC ON
+             AUTOUIC ON
+             AUTORCC ON)

--- a/cmake/os-windows.cmake
+++ b/cmake/os-windows.cmake
@@ -1,0 +1,34 @@
+target_compile_options(obs-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
+target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+
+target_link_libraries(obs-browser PRIVATE CEF::Wrapper CEF::Library d3d11 dxgi)
+target_link_options(obs-browser PRIVATE /IGNORE:4099)
+
+add_executable(obs-browser-helper WIN32 EXCLUDE_FROM_ALL)
+add_executable(OBS::browser-helper ALIAS obs-browser-helper)
+
+target_sources(
+  obs-browser-helper
+  PRIVATE cef-headers.hpp
+          obs-browser-page/obs-browser-page-main.cpp
+          browser-app.cpp
+          browser-app.hpp
+          deps/json11/json11.cpp
+          deps/json11/json11.hpp
+          obs-browser-page.manifest)
+
+target_include_directories(obs-browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
+                                                      "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")
+
+target_compile_options(obs-browser-helper PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
+target_compile_definitions(obs-browser-helper PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+
+target_link_libraries(obs-browser-helper PRIVATE CEF::Wrapper CEF::Library)
+target_link_options(obs-browser-helper PRIVATE /IGNORE:4099 /SUBSYSTEM:WINDOWS)
+
+set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
+set_target_properties_obs(
+  obs-browser-helper
+  PROPERTIES FOLDER plugins/obs-browser
+             PREFIX ""
+             OUTPUT_NAME obs-browser-page)

--- a/cmake/windows/obs-browser-page.manifest
+++ b/cmake/windows/obs-browser-page.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <description>OBS Browser Page (CEF)</description>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <maxversiontested Id="10.0.22000.0"/>
+            <!-- Windows 10 and Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
+</assembly>

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -32,7 +32,6 @@
 #include "browser-scheme.hpp"
 #include "browser-app.hpp"
 #include "browser-version.h"
-#include "browser-config.h"
 
 #include "json11/json11.hpp"
 #include "obs-websocket-api/obs-websocket-api.h"

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -21,7 +21,6 @@
 #include <obs-module.h>
 
 #include "cef-headers.hpp"
-#include "browser-config.h"
 #include "browser-app.hpp"
 #include <atomic>
 #include <functional>

--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -79,11 +79,12 @@ void QCefBrowserClient::OnTitleChange(CefRefPtr<CefBrowser> browser,
 		if (title.compare("DevTools") == 0)
 			return;
 
+#if defined(_WIN32)
 		CefWindowHandle handl = browser->GetHost()->GetWindowHandle();
-#ifdef _WIN32
 		std::wstring str_title = title;
 		SetWindowTextW((HWND)handl, str_title.c_str());
 #elif defined(__linux__)
+		CefWindowHandle handl = browser->GetHost()->GetWindowHandle();
 		XStoreName(cef_get_xdisplay(), handl, title.ToString().c_str());
 #endif
 	}


### PR DESCRIPTION
### Description
This PR updates the CMake build files to be compatible with the build system 3.0 update on the main repository.

### Motivation and Context

* The current build script is retained as the "legacy" script (which will still be used to generate build projects on Linux and macOS)
* The new build script is used for macOS builds by default at first

The updated build system enforces uses Xcode by default on macOS and has some stricter code requirements, which are also fixed by this PR:

* Shadowing is fixed (new variables created in local scope with the same name as existing instance variables, thus shadowing them).
* Implicit casts are changed to be explicit (mainly for data being passed from data types with different bit-depth) - while data loss is still possible, the casts make it explicit that the developer is aware of this possible issues and wants to ignore it.

More information shall be available in the pull request on the main repository.

Note: This PR needs to be merged first, then the associated commit hash updated for the obs-browser submodule at obs-studio.

### How Has This Been Tested?
* New build scripts were tested as part of the overall update on macOS 13, Ubuntu 22.10, and Windows 11.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
