### PR TITLE
Increased maximum width and height

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -186,9 +186,9 @@ static obs_properties_t *browser_source_get_properties(void *data)
 				OBS_TEXT_DEFAULT);
 
 	obs_properties_add_int(props, "width", obs_module_text("Width"), 1,
-			       4096, 1);
+			       8192, 1);
 	obs_properties_add_int(props, "height", obs_module_text("Height"), 1,
-			       4096, 1);
+			       8192, 1);
 
 	obs_properties_add_bool(props, "reroute_audio",
 				obs_module_text("RerouteAudio"));


### PR DESCRIPTION
### Description
The maximum width and height are currently 4096 pixels, and this pull request double the maximum to 8192 pixels.

### Motivation and Context

This change is required to support higher resolutions, such as 7680x4320 (8K).

### How Has This Been Tested?
I compiled and run OBS on my laptop. I tested various webpages at low and high resolutions, including some webgl demos.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Feel free to close or reject my pull-request.