### PR TITLE
Fix leak with SchemeHandlerFactory

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -419,6 +419,9 @@ static void BrowserInit(void)
 
 static void BrowserShutdown(void)
 {
+#if !ENABLE_LOCAL_FILE_URL_SCHEME
+	CefClearSchemeHandlerFactories();
+#endif
 #ifdef ENABLE_BROWSER_QT_LOOP
 	while (messageObject.ExecuteNextBrowserTask())
 		;


### PR DESCRIPTION
### Description
This clears a BrowserSchemeHandlerFactory which caused a memory leak.

### Motivation and Context
Noticed this leak when running Visual Leak Detector.
This leak was introduced in 2015 in:
https://github.com/obsproject/obs-browser/commit/2d898bf6acc1c66359d5f69d39428ed2c1fb9826
So it's been there forever. @_@ 

### How Has This Been Tested?
The leak is now gone when  VLD runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
