### PR TITLE
Replace SIGNAL and SLOT macro

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -412,7 +412,8 @@ void QCefWidgetInternal::showEvent(QShowEvent *event)
 
 	if (!cefBrowser) {
 		obs_browser_initialize();
-		connect(&timer, SIGNAL(timeout()), this, SLOT(Init()));
+		connect(&timer, &QTimer::timeout, this,
+			&QCefWidgetInternal::Init);
 		timer.start(500);
 		Init();
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
First part of my quest to replace all uses of the `SIGNAL` and `SLOT` macros with the "new" (Qt 5+) connection style.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I will write a longer paragraph on the upcoming obs-studio PR, but essentially using this new connection style is superior in pretty much every way.
This is because it catches issues with wrong connections at compile-time instead of at runtime, making sure bugs don't make their way into the program, of which we've had quite a few in the past.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2 with master obs-studio
Tested with a debugger and by commenting out the `!cefBrowser` if-statement above and the `Init()` call directly below that when using a dock, the Init() gets called with the connect statement and doesn't get called without it; and that browser docks and sources work.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
