### PR TITLE
Add ability to zoom browser docks with Ctrl - and +

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -33,6 +33,10 @@ Error.Retry="Click here to retry"
 Error.Code="Error: %1"
 Error.URL="URL: %2"
 
+Zoom.Reset="Reset Zoom"
+Zoom.Out="Zoom out"
+Zoom.In="Zoom in"
+
 # Error codes in CEF are fetched direct from Chromium
 # CEF Reference: https://bitbucket.org/chromiumembedded/cef/src/master/include/base/internal/cef_net_error_list.h
 # Chromium Reference: https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h#

--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -21,6 +21,9 @@
 
 #define MENU_ITEM_DEVTOOLS MENU_ID_CUSTOM_FIRST
 #define MENU_ITEM_MUTE MENU_ID_CUSTOM_FIRST + 1
+#define MENU_ITEM_ZOOM_IN MENU_ID_CUSTOM_FIRST + 2
+#define MENU_ITEM_ZOOM_RESET MENU_ID_CUSTOM_FIRST + 3
+#define MENU_ITEM_ZOOM_OUT MENU_ID_CUSTOM_FIRST + 4
 
 /* CefClient */
 CefRefPtr<CefLoadHandler> QCefBrowserClient::GetLoadHandler()
@@ -252,6 +255,12 @@ void QCefBrowserClient::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 	if (model->IsVisible(MENU_ID_VIEW_SOURCE)) {
 		model->Remove(MENU_ID_VIEW_SOURCE);
 	}
+	model->AddItem(MENU_ITEM_ZOOM_IN, obs_module_text("Zoom.In"));
+	if (browser->GetHost()->GetZoomLevel() != 0) {
+		model->AddItem(MENU_ITEM_ZOOM_RESET,
+			       obs_module_text("Zoom.Reset"));
+	}
+	model->AddItem(MENU_ITEM_ZOOM_OUT, obs_module_text("Zoom.Out"));
 	model->AddSeparator();
 	model->InsertItemAt(model->GetCount(), MENU_ITEM_DEVTOOLS,
 			    obs_module_text("Inspect"));
@@ -351,6 +360,15 @@ bool QCefBrowserClient::OnContextMenuCommand(
 		return true;
 	case MENU_ITEM_MUTE:
 		host->SetAudioMuted(!host->IsAudioMuted());
+		return true;
+	case MENU_ITEM_ZOOM_IN:
+		widget->zoomPage(1);
+		return true;
+	case MENU_ITEM_ZOOM_RESET:
+		widget->zoomPage(0);
+		return true;
+	case MENU_ITEM_ZOOM_OUT:
+		widget->zoomPage(-1);
 		return true;
 	}
 	return false;
@@ -469,6 +487,21 @@ bool QCefBrowserClient::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
 #endif
 		browser->ReloadIgnoreCache();
 		return true;
+	} else if ((event.windows_key_code == 189 ||
+		    event.windows_key_code == 109) &&
+		   (event.modifiers & EVENTFLAG_CONTROL_DOWN) != 0) {
+		// Zoom out
+		return widget->zoomPage(-1);
+	} else if ((event.windows_key_code == 187 ||
+		    event.windows_key_code == 107) &&
+		   (event.modifiers & EVENTFLAG_CONTROL_DOWN) != 0) {
+		// Zoom in
+		return widget->zoomPage(1);
+	} else if ((event.windows_key_code == 48 ||
+		    event.windows_key_code == 96) &&
+		   (event.modifiers & EVENTFLAG_CONTROL_DOWN) != 0) {
+		// Reset zoom
+		return widget->zoomPage(0);
 	}
 	return false;
 }

--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -52,6 +52,7 @@ public:
 	virtual void allowAllPopups(bool allow) override;
 	virtual void closeBrowser() override;
 	virtual void reloadPage() override;
+	virtual bool zoomPage(int direction) override;
 
 	void Resize();
 

--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -19,6 +19,7 @@
 #include <util/threading.h>
 #include <util/base.h>
 #include <thread>
+#include <cmath>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <X11/Xlib.h>
@@ -31,6 +32,9 @@ extern os_event_t *cef_started_event;
 std::mutex popup_whitelist_mutex;
 std::vector<PopupWhitelistInfo> popup_whitelist;
 std::vector<PopupWhitelistInfo> forced_popups;
+
+static int zoomLvls[] = {25,  33,  50,  67,  75,  80,  90,  100,
+			 110, 125, 150, 175, 200, 250, 300, 400};
 
 /* ------------------------------------------------------------------------- */
 
@@ -448,6 +452,49 @@ void QCefWidgetInternal::setStartupScript(const std::string &script_)
 void QCefWidgetInternal::allowAllPopups(bool allow)
 {
 	allowAllPopups_ = allow;
+}
+
+bool QCefWidgetInternal::zoomPage(int direction)
+{
+	if (!cefBrowser || direction < -1 || direction > 1)
+		return false;
+
+	CefRefPtr<CefBrowserHost> host = cefBrowser->GetHost();
+	if (direction == 0) {
+		// Reset zoom
+		host->SetZoomLevel(0);
+		return true;
+	}
+
+	int currentZoomPercent = round(pow(1.2, host->GetZoomLevel()) * 100.0);
+	int zoomCount = sizeof(zoomLvls) / sizeof(zoomLvls[0]);
+	int zoomIdx = 0;
+
+	while (zoomIdx < zoomCount) {
+		if (zoomLvls[zoomIdx] == currentZoomPercent) {
+			break;
+		}
+		zoomIdx++;
+	}
+	if (zoomIdx == zoomCount)
+		return false;
+
+	int newZoomIdx = zoomIdx;
+	if (direction == -1 && zoomIdx > 0) {
+		// Zoom out
+		newZoomIdx -= 1;
+	} else if (direction == 1 && zoomIdx >= 0 && zoomIdx < zoomCount - 1) {
+		// Zoom in
+		newZoomIdx += 1;
+	}
+
+	if (newZoomIdx != zoomIdx) {
+		int newZoomLvl = zoomLvls[newZoomIdx];
+		// SetZoomLevel only accepts a zoomLevel, not a percentage
+		host->SetZoomLevel(log(newZoomLvl / 100.0) / log(1.2));
+		return true;
+	}
+	return false;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/panel/browser-panel.hpp
+++ b/panel/browser-panel.hpp
@@ -46,6 +46,7 @@ public:
 	virtual void allowAllPopups(bool allow) = 0;
 	virtual void closeBrowser() = 0;
 	virtual void reloadPage() = 0;
+	virtual bool zoomPage(int direction) = 0;
 
 signals:
 	void titleChanged(const QString &title);


### PR DESCRIPTION
### Description

Adds the ability for a user to control the zoom level of a browser dock using keyboard shortcuts.

Ctrl + 0 resets zoom, like a normal browser.

Attempts to use the same % values as browsers.

Also adds a Reset option to the context menu when zoom is not 100%.

Verify the zoom level using the following in the Inspect window:

`Math.round(window.devicePixelRatio * 100);`

~~Note that zoom level does not persist across restarts. However, even in this initial implementation it's more useful than not having it.~~ Zoom level now persists thanks to https://github.com/obsproject/obs-browser/commit/4236b56fbe4706de17617b2fe69370b031294b29

https://user-images.githubusercontent.com/941350/226282748-f2b495bf-5d8e-4a1f-9d89-bec84a745b92.mp4

https://user-images.githubusercontent.com/941350/226282777-c6a7daef-d0d9-452a-bf1d-d9d9a093c0a6.mp4

### Motivation and Context

- Accessibility.
- This is a feature that has often been requested.
- https://ideas.obsproject.com/posts/2049/zoom-tool-in-internal-browser
- Users don't often have control of the pages within their docks, and may need them zoomed in for various reasons.

### How Has This Been Tested?

On Windows.

1. Press the mentioned hotkeys while a browser dock is focused.
2. Right click a browser dock with a non-100% zoom and select Reset Zoom.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
