### PR TITLE
CI: Fix build errors with Xcode 14.3 and platform SDK 13.3

### DIFF
--- a/cmake/os-macos.cmake
+++ b/cmake/os-macos.cmake
@@ -5,6 +5,9 @@ find_library(APPKIT AppKit)
 mark_as_advanced(COREFOUNDATION APPKIT)
 
 target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE ENABLE_BROWSER_QT_LOOP)
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
+  target_compile_options(obs-browser PRIVATE -Wno-error=unqualified-std-cast-call)
+endif()
 
 target_link_libraries(obs-browser PRIVATE Qt::Widgets ${COREFOUNDATION} ${APPKIT} CEF::Wrapper)
 
@@ -31,6 +34,9 @@ foreach(helper IN LISTS helper_suffixes)
   target_sources(${target_name} PRIVATE browser-app.cpp browser-app.hpp obs-browser-page/obs-browser-page-main.cpp
                                         cef-headers.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
   target_compile_definitions(${target_name} PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+  if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
+    target_compile_options(${target_name} PRIVATE -Wno-error=unqualified-std-cast-call)
+  endif()
 
   target_include_directories(${target_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
                                                     "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")
@@ -41,7 +47,7 @@ foreach(helper IN LISTS helper_suffixes)
     ${target_name}
     PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info-Helper${helper_plist}.plist"
                OUTPUT_NAME "${target_output_name}"
-               FOLDER plugins/obs-browser/helper_suffixes
+               FOLDER plugins/obs-browser/Helpers
                XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.obsproject.obs-studio.helper${helper_plist}
                XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/entitlements-helper${helper_plist}.plist")


### PR DESCRIPTION
### Description
Makes warning about unqualified `std::` calls a non-error.

### Motivation and Context
Xcode 14.3 and the macOS 13.3 platform SDK introduced a few breaking changes:

* Updated AppleClang emits warnings about unqualified std cast calls when using C++ - as `move` is too broad a word, developers are to use `std::move` to make this explicit. Alas this is exactly what `json11` uses and because that library is archived, there is no possibility of an upstream update.

This will also affect any platform that uses recent `clang` to compile obs-studio, but for now it mainly seems to affect macOS.


### How Has This Been Tested?
Tested with Xcode 14.3 and AppleClang 14.0.3

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
