### PR TITLE
Move browser-panel ObjC code to Objective-C file; Add more null checks

### DIFF
--- a/cmake/feature-panels.cmake
+++ b/cmake/feature-panels.cmake
@@ -12,6 +12,10 @@ target_compile_definitions(browser-panels INTERFACE BROWSER_AVAILABLE)
 target_sources(obs-browser PRIVATE panel/browser-panel-client.hpp panel/browser-panel-internal.hpp
                                    panel/browser-panel.cpp panel/browser-panel-client.cpp)
 
+if(OS_MACOS)
+  target_sources(obs-browser PRIVATE panel/browser-panel-macos.m)
+endif()
+
 target_link_libraries(obs-browser PRIVATE OBS::browser-panels Qt::Widgets)
 
 set_target_properties(

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -244,6 +244,7 @@ if(ENABLE_BROWSER_PANELS)
   target_link_libraries(obs-browser-panels INTERFACE CEF::Wrapper)
 
   if(OS_MACOS)
+    target_sources(obs-browser PRIVATE panel/browser-panel-macos.m)
     target_link_libraries(obs-browser-panels INTERFACE objc)
   endif()
 

--- a/panel/browser-panel-macos.m
+++ b/panel/browser-panel-macos.m
@@ -1,0 +1,15 @@
+#import <AppKit/AppKit.h>
+
+void RemoveNSViewFromSuperview(void *view)
+{
+	if (!view)
+		return;
+
+	if (!*((bool *)view))
+		return;
+
+	// CefBrowserHostView is a subclass of NSView
+	// and we just need the superclass here
+	NSView *nsview = (NSView *)view;
+	[nsview removeFromSuperview];
+}

--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -11,10 +11,6 @@
 #include <QThread>
 #endif
 
-#ifdef __APPLE__
-#include <objc/objc.h>
-#endif
-
 #include <obs-module.h>
 #include <util/threading.h>
 #include <util/base.h>
@@ -161,6 +157,10 @@ QCefWidgetInternal::~QCefWidgetInternal()
 	closeBrowser();
 }
 
+#ifdef __APPLE__
+extern "C" void RemoveNSViewFromSuperview(void *view);
+#endif
+
 void QCefWidgetInternal::closeBrowser()
 {
 	CefRefPtr<CefBrowser> browser = cefBrowser;
@@ -203,10 +203,8 @@ void QCefWidgetInternal::closeBrowser()
 		}
 #elif __APPLE__
 		// felt hacky, might delete later
-		void *view = (id)cefBrowser->GetHost()->GetWindowHandle();
-		if (*((bool *)view))
-			((void (*)(id, SEL))objc_msgSend)(
-				(id)view, sel_getUid("removeFromSuperview"));
+		void *view = cefBrowser->GetHost()->GetWindowHandle();
+		RemoveNSViewFromSuperview(view);
 #endif
 
 		destroyBrowser(browser);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Moves the Objective-C calls in `browser-panel.cpp` into an actual Objective-C file, making it more readable.
Also adds a `!view` null check in addition to the existing `!*((bool *)view)` which might fix a newly reported crash.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
https://github.com/obsproject/obs-studio/issues/8836 was reported and maybe the first null check fixes it. I have no idea if it actually does since I can't reproduce the crash in the first place.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3.1
Made sure that the crash of the original null check added in #374 didn't regress by using twitch integration with and without the call to `RemoveNSViewFromSuperview`.
Whether or not the new crash is fixed I don't know, I guess we'll see when we deploy to production.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) --->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
