### PR TITLE
Add JS interaction function, Fix "setStartupScript"

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -398,7 +398,12 @@ bool QCefBrowserClient::OnContextMenuCommand(
 void QCefBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>,
 				  CefRefPtr<CefFrame> frame, int)
 {
-	if (frame->IsMain() && !script.empty())
+	if (!frame->IsMain())
+		return;
+
+	if (widget && !widget->script.empty())
+		frame->ExecuteJavaScript(widget->script, CefString(), 0);
+	else if (!script.empty())
 		frame->ExecuteJavaScript(script, CefString(), 0);
 }
 

--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -53,6 +53,7 @@ public:
 	virtual void closeBrowser() override;
 	virtual void reloadPage() override;
 	virtual bool zoomPage(int direction) override;
+	virtual void executeJavaScript(const std::string &script) override;
 
 	void Resize();
 

--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -449,6 +449,16 @@ void QCefWidgetInternal::setStartupScript(const std::string &script_)
 	script = script_;
 }
 
+void QCefWidgetInternal::executeJavaScript(const std::string &script_)
+{
+	if (!cefBrowser)
+		return;
+
+	CefRefPtr<CefFrame> frame = cefBrowser->GetMainFrame();
+	std::string url = frame->GetURL();
+	frame->ExecuteJavaScript(script_, url, 0);
+}
+
 void QCefWidgetInternal::allowAllPopups(bool allow)
 {
 	allowAllPopups_ = allow;

--- a/panel/browser-panel.hpp
+++ b/panel/browser-panel.hpp
@@ -47,6 +47,7 @@ public:
 	virtual void closeBrowser() = 0;
 	virtual void reloadPage() = 0;
 	virtual bool zoomPage(int direction) = 0;
+	virtual void executeJavaScript(const std::string &script) = 0;
 
 signals:
 	void titleChanged(const QString &title);


### PR DESCRIPTION
# Add JS interaction function, Fix "setStartupScript"
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
This PR is a try to provide top-level JS interaction function "executeJavaScript", that makes possible calling JS from the end code.
Additionally, this PR allows changing startup script (using "setStartupScript") at runtime. Current implementation remembers very first setStartupScript call and ignores subsequent calls. With this PR we can change JS startup script without recreating cef browser at any time.

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
1. Add new top-level JS interaction function, "executeJavaScript()",
1. Fix "setStartupScript()" to allow top-level code change the startup script during execution.

### Motivation and Context
* We need the ability to run js code from a client app.
* Startup script is autorun every URL change/reload, so we need the change to update it without re-creating the browser,

This changes are part of main [obs-studio PR](https://github.com/obsproject/obs-studio/pull/9031).

### How Has This Been Tested?
Tested manually as part of [main PR](https://github.com/obsproject/obs-studio/pull/9031).
* Windows 10 x64, Linux Ubuntu 22.04, macOS M1 Ventura, macOS x86_64 Catalina.

These changes should not affect existing code
 * except possible bug with changing startup script during execution, but I haven't seen such one in bug tracker.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
