### PR TITLE
Add option to set html

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -651,11 +651,20 @@ void BrowserClient::OnAudioStreamStopped(CefRefPtr<CefBrowser> browser, int id)
 void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame,
 			      int)
 {
-	if (!valid()) {
+	if (!valid() || !frame->IsMain()) {
 		return;
 	}
+	if (bs->content_type == ContentType::HTML) {
+		std::string uriEncodedHTML =
+			CefURIEncode(bs->html, false).ToString();
 
-	if (frame->IsMain() && bs->css.length()) {
+		std::string script =
+			"document.body.innerHTML = decodeURIComponent(\"" +
+			uriEncodedHTML + "\");";
+
+		frame->ExecuteJavaScript(script, "", 0);
+	}
+	if (bs->css.length()) {
 		std::string uriEncodedCSS =
 			CefURIEncode(bs->css, false).ToString();
 

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,5 +1,7 @@
-LocalFile="Local file"
+ContentType="Content type"
 URL="URL"
+LocalFile="Local file"
+HTML="HTML"
 Width="Width"
 Height="Height"
 FPS="FPS"

--- a/obs-browser-source.hpp
+++ b/obs-browser-source.hpp
@@ -50,6 +50,12 @@ enum class ControlLevel : int {
 };
 inline constexpr ControlLevel DEFAULT_CONTROL_LEVEL = ControlLevel::ReadObs;
 
+enum class ContentType : int {
+	URL,
+	LocalFile,
+	HTML,
+};
+
 extern bool hwaccel;
 
 struct BrowserSource {
@@ -64,6 +70,7 @@ struct BrowserSource {
 	CefRefPtr<CefBrowser> cefBrowser;
 
 	std::string url;
+	std::string html;
 	std::string css;
 	gs_texture_t *texture = nullptr;
 	gs_texture_t *extra_texture = nullptr;
@@ -86,7 +93,7 @@ struct BrowserSource {
 	double canvas_fps = 0;
 	bool restart = false;
 	bool shutdown_on_invisible = false;
-	bool is_local = false;
+	ContentType content_type = ContentType::URL;
 	bool first_update = true;
 	bool reroute_audio = true;
 	std::atomic<bool> destroying = false;


### PR DESCRIPTION
### Description
Add option to set html instead of url or local file

### Motivation and Context
Want to be able to display html and control the contents from plugins and scripts without having to host a file.
![image](https://github.com/obsproject/obs-browser/assets/5457024/29972755-62cf-4f73-8a97-6fec204c52d1)
When changing the css or html the browser only changes that part instead of destroying and creating a new browser.

### How Has This Been Tested?
On windows11 by setting html as shown in above screenshot

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
