### PR TITLE
Disable Bluetooth support

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -83,10 +83,12 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 		std::string disableFeatures =
 			command_line->GetSwitchValue("disable-features");
 		disableFeatures += ",HardwareMediaKeyHandling";
+		disableFeatures += ",WebBluetooth";
 		command_line->AppendSwitchWithValue("disable-features",
 						    disableFeatures);
 	} else {
 		command_line->AppendSwitchWithValue("disable-features",
+						    "WebBluetooth,"
 						    "HardwareMediaKeyHandling");
 	}
 


### PR DESCRIPTION
### Description

The integrated browser is not supposed to be a fully featured web browser, but rather provide support for modern web standards that can be integrated neatly into an overlay or the UI via a panel.

WebBluetooth requires additional system permissions (especially on macOS) and can potentially cause OBS to crash if those permissions are denied or missing. That's not ideal either.

### Motivation and Context

@gxalpha ran into a crash on their local builds when certain browser panels attempted to request Bluetooth permission because the `Info.plist` for OBS does not list Bluetooth. CI builds (at the moment) seem to query the OS correctly and a system-level request Bluetooth permission, however there is no reason we can think of why the browser currently should have access to Bluetooth.

### How Has This Been Tested?

* Launch OBS on macOS in a local dev environment

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
