### PR TITLE
cmake: Update formatting and switch to native find_package call for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,7 @@ mark_as_advanced(ENABLE_BROWSER_PANELS)
 
 target_sources(
   obs-browser
-  PRIVATE obs-browser-plugin.cpp
-          obs-browser-source.cpp
-          obs-browser-source.hpp
-          obs-browser-source-audio.cpp
+  PRIVATE # cmake-format: sortable
           browser-app.cpp
           browser-app.hpp
           browser-client.cpp
@@ -36,11 +33,15 @@ target_sources(
           cef-headers.hpp
           deps/base64/base64.cpp
           deps/base64/base64.hpp
-          deps/wide-string.cpp
-          deps/wide-string.hpp
+          deps/obs-websocket-api/obs-websocket-api.h
           deps/signal-restore.cpp
           deps/signal-restore.hpp
-          deps/obs-websocket-api/obs-websocket-api.h)
+          deps/wide-string.cpp
+          deps/wide-string.hpp
+          obs-browser-plugin.cpp
+          obs-browser-source-audio.cpp
+          obs-browser-source.cpp
+          obs-browser-source.hpp)
 
 target_include_directories(obs-browser PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps")
 

--- a/cmake/feature-panels.cmake
+++ b/cmake/feature-panels.cmake
@@ -1,4 +1,4 @@
-find_qt(COMPONENTS Widgets)
+find_package(Qt6 REQUIRED Widgets)
 
 add_library(browser-panels INTERFACE)
 add_library(OBS::browser-panels ALIAS browser-panels)
@@ -9,8 +9,11 @@ target_include_directories(browser-panels INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}
 
 target_compile_definitions(browser-panels INTERFACE BROWSER_AVAILABLE)
 
-target_sources(obs-browser PRIVATE panel/browser-panel-client.hpp panel/browser-panel-internal.hpp
-                                   panel/browser-panel.cpp panel/browser-panel-client.cpp)
+target_sources(
+  obs-browser
+  PRIVATE # cmake-format: sortable
+          panel/browser-panel-client.cpp panel/browser-panel-client.hpp panel/browser-panel-internal.hpp
+          panel/browser-panel.cpp)
 
 target_link_libraries(obs-browser PRIVATE OBS::browser-panels Qt::Widgets)
 
@@ -19,3 +22,7 @@ set_target_properties(
   PROPERTIES AUTOMOC ON
              AUTOUIC ON
              AUTORCC ON)
+
+if(OS_WINDOWS)
+  set_property(SOURCE browser-app.hpp PROPERTY SKIP_AUTOMOC TRUE)
+endif()

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -137,12 +137,6 @@ if(NOT OS_MACOS OR ENABLE_BROWSER_LEGACY)
 endif()
 
 if(OS_WINDOWS)
-  if(MSVC)
-    target_compile_options(obs-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
-
-    target_compile_options(obs-browser-page PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
-  endif()
-
   target_link_libraries(obs-browser PRIVATE CEF::Library d3d11 dxgi)
 
   if(TARGET CEF::Wrapper_Debug)

--- a/cmake/os-linux.cmake
+++ b/cmake/os-linux.cmake
@@ -6,8 +6,9 @@ set_target_properties(obs-browser PROPERTIES BUILD_RPATH "$ORIGIN/" INSTALL_RPAT
 add_executable(browser-helper)
 add_executable(OBS::browser-helper ALIAS browser-helper)
 
-target_sources(browser-helper PRIVATE cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp browser-app.cpp
-                                      browser-app.hpp deps/json11/json11.cpp deps/json11/json11.hpp)
+target_sources(
+  browser-helper PRIVATE # cmake-format: sortable
+                         browser-app.cpp browser-app.hpp cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp)
 
 target_include_directories(browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
                                                   "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")
@@ -15,6 +16,8 @@ target_include_directories(browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/d
 target_link_libraries(browser-helper PRIVATE CEF::Wrapper CEF::Library)
 
 set(OBS_EXECUTABLE_DESTINATION "${OBS_PLUGIN_DESTINATION}")
+
+# cmake-format: off
 set_target_properties_obs(
   browser-helper
   PROPERTIES FOLDER plugins/obs-browser
@@ -22,3 +25,4 @@ set_target_properties_obs(
              INSTALL_RPATH "$ORIGIN/"
              PREFIX ""
              OUTPUT_NAME obs-browser-page)
+# cmake-format: on

--- a/cmake/os-macos.cmake
+++ b/cmake/os-macos.cmake
@@ -1,15 +1,13 @@
-find_qt(COMPONENTS Widgets)
-
-find_library(COREFOUNDATION CoreFoundation)
-find_library(APPKIT AppKit)
-mark_as_advanced(COREFOUNDATION APPKIT)
+find_package(Qt6 REQUIRED Widgets)
 
 target_compile_definitions(obs-browser PRIVATE ENABLE_BROWSER_SHARED_TEXTURE ENABLE_BROWSER_QT_LOOP)
+
 if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
   target_compile_options(obs-browser PRIVATE -Wno-error=unqualified-std-cast-call)
 endif()
 
-target_link_libraries(obs-browser PRIVATE Qt::Widgets ${COREFOUNDATION} ${APPKIT} CEF::Wrapper)
+target_link_libraries(obs-browser PRIVATE Qt::Widgets CEF::Wrapper "$<LINK_LIBRARY:FRAMEWORK,CoreFoundation.framework>"
+                                          "$<LINK_LIBRARY:FRAMEWORK,AppKit.framework>")
 
 set(helper_basename browser-helper)
 set(helper_output_name "OBS Helper")
@@ -31,9 +29,12 @@ foreach(helper IN LISTS helper_suffixes)
   add_executable(${target_name} MACOSX_BUNDLE EXCLUDE_FROM_ALL)
   add_executable(OBS::${target_name} ALIAS ${target_name})
 
-  target_sources(${target_name} PRIVATE browser-app.cpp browser-app.hpp obs-browser-page/obs-browser-page-main.cpp
-                                        cef-headers.hpp)
+  target_sources(
+    ${target_name} PRIVATE # cmake-format: sortable
+                           browser-app.cpp browser-app.hpp cef-headers.hpp obs-browser-page/obs-browser-page-main.cpp)
+
   target_compile_definitions(${target_name} PRIVATE ENABLE_BROWSER_SHARED_TEXTURE)
+
   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
     target_compile_options(${target_name} PRIVATE -Wno-error=unqualified-std-cast-call)
   endif()

--- a/cmake/os-windows.cmake
+++ b/cmake/os-windows.cmake
@@ -9,11 +9,9 @@ add_executable(OBS::browser-helper ALIAS obs-browser-helper)
 
 target_sources(
   obs-browser-helper
-  PRIVATE cef-headers.hpp
-          obs-browser-page/obs-browser-page-main.cpp
-          browser-app.cpp
-          browser-app.hpp
-          obs-browser-page.manifest)
+  PRIVATE # cmake-format: sortable
+          browser-app.cpp browser-app.hpp cef-headers.hpp obs-browser-page.manifest
+          obs-browser-page/obs-browser-page-main.cpp)
 
 target_include_directories(obs-browser-helper PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser-page")


### PR DESCRIPTION
### Description
Updates the CMake build script for the submodule as a companion PR to https://github.com/obsproject/obs-studio/pull/9769.

### Motivation and Context
Clean up the code and remove unnecessary build specifics.

The main breaking change of this PR is that it correctly requires the wrapper library to be built according to the [official documentation](https://bitbucket.org/chromiumembedded/cef/wiki/LinkingDifferentRunTimeLibraries.md) for Windows:

~~Linking CEF dynamically (as `obs-browser` does) requires the use of the dynamic MSVC runtime library and also disabling the sandbox functionality.~~

(Runtime library changes on Windows have been moved to a separate PR).

Current code works around this issue by forcing the runtime library to be linked statically, a workaround which is removed by this PR.

### How Has This Been Tested?
Tested on Windows 11 with an updated wrapper library (built according to the documentation).

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
