### PR TITLE
Don't allow browser docks to arbitrarily close OBS

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -405,6 +405,12 @@ void QCefBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>,
 		frame->ExecuteJavaScript(widget->script, CefString(), 0);
 	else if (!script.empty())
 		frame->ExecuteJavaScript(script, CefString(), 0);
+
+	std::string script2 = "window.close = () => ";
+	script2 += "console.log(";
+	script2 += "'OBS browser docks cannot be closed using JavaScript.'";
+	script2 += ");";
+	frame->ExecuteJavaScript(script2, "", 0);
 }
 
 bool QCefBrowserClient::OnJSDialog(CefRefPtr<CefBrowser>, const CefString &,


### PR DESCRIPTION
### Description

This overrides the built-in `window.close` of Chromium with a no-op.

I tried alternatives that weren't as hacky, however they either aren't cancellable or didn't specify which frame made the request (or the reason for the close request).

### Motivation and Context

Certain third party browser docks call `window.close` for whatever reason, which causes OBS to close. We don't approve.

### How Has This Been Tested?

Open a browser dock.
Right click and Inspect.
Type `window.close()` in the Console.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
