### PR TITLE
Fix handling frontend JS events

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -549,55 +549,55 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 {
 	switch (event) {
 	case OBS_FRONTEND_EVENT_STREAMING_STARTING:
-		DispatchJSEvent("obsStreamingStarting", "");
+		DispatchJSEvent("obsStreamingStarting", "null");
 		break;
 	case OBS_FRONTEND_EVENT_STREAMING_STARTED:
-		DispatchJSEvent("obsStreamingStarted", "");
+		DispatchJSEvent("obsStreamingStarted", "null");
 		break;
 	case OBS_FRONTEND_EVENT_STREAMING_STOPPING:
-		DispatchJSEvent("obsStreamingStopping", "");
+		DispatchJSEvent("obsStreamingStopping", "null");
 		break;
 	case OBS_FRONTEND_EVENT_STREAMING_STOPPED:
-		DispatchJSEvent("obsStreamingStopped", "");
+		DispatchJSEvent("obsStreamingStopped", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_STARTING:
-		DispatchJSEvent("obsRecordingStarting", "");
+		DispatchJSEvent("obsRecordingStarting", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_STARTED:
-		DispatchJSEvent("obsRecordingStarted", "");
+		DispatchJSEvent("obsRecordingStarted", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_PAUSED:
-		DispatchJSEvent("obsRecordingPaused", "");
+		DispatchJSEvent("obsRecordingPaused", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_UNPAUSED:
-		DispatchJSEvent("obsRecordingUnpaused", "");
+		DispatchJSEvent("obsRecordingUnpaused", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPING:
-		DispatchJSEvent("obsRecordingStopping", "");
+		DispatchJSEvent("obsRecordingStopping", "null");
 		break;
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
-		DispatchJSEvent("obsRecordingStopped", "");
+		DispatchJSEvent("obsRecordingStopped", "null");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING:
-		DispatchJSEvent("obsReplaybufferStarting", "");
+		DispatchJSEvent("obsReplaybufferStarting", "null");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED:
-		DispatchJSEvent("obsReplaybufferStarted", "");
+		DispatchJSEvent("obsReplaybufferStarted", "null");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED:
-		DispatchJSEvent("obsReplaybufferSaved", "");
+		DispatchJSEvent("obsReplaybufferSaved", "null");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING:
-		DispatchJSEvent("obsReplaybufferStopping", "");
+		DispatchJSEvent("obsReplaybufferStopping", "null");
 		break;
 	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED:
-		DispatchJSEvent("obsReplaybufferStopped", "");
+		DispatchJSEvent("obsReplaybufferStopped", "null");
 		break;
 	case OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED:
-		DispatchJSEvent("obsVirtualcamStarted", "");
+		DispatchJSEvent("obsVirtualcamStarted", "null");
 		break;
 	case OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED:
-		DispatchJSEvent("obsVirtualcamStopped", "");
+		DispatchJSEvent("obsVirtualcamStopped", "null");
 		break;
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED: {
 		OBSSourceAutoRelease source = obs_frontend_get_current_scene();
@@ -663,7 +663,7 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		break;
 	}
 	case OBS_FRONTEND_EVENT_EXIT:
-		DispatchJSEvent("obsExit", "");
+		DispatchJSEvent("obsExit", "null");
 		break;
 	default:;
 	}

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -642,7 +642,9 @@ static void handle_obs_frontend_event(enum obs_frontend_event event, void *)
 		if (!name)
 			break;
 
-		DispatchJSEvent("obsTransitionChanged", name);
+		nlohmann::json json = {{"name", name}};
+
+		DispatchJSEvent("obsTransitionChanged", json.dump());
 		break;
 	}
 	case OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED: {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When handling frontend events, DispatchJSEvent expects JSON passed as a std::string. An unquoted string is not valid JSON. To get valid JSON, we can build a JSON object like in OBS_FRONTEND_EVENT_SCENE_CHANGED and pass the result of dump() to DispatchJSEvent.

When handling frontend events, DispatchJSEvent expects JSON passed as a std::string. An empty string will cause the event to never be dispatched. An empty nlohmann::json object converted to a std::string is represented by the string "null". Passing this exact string as the JSON string to DispatchJSEvent makes the events work. This is probably because an empty unquoted string by itself is not valid JSON. Two double-quotes with nothing inside them or the unquoted string "null" are considered valid JSON.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #428 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
