### PR TITLE
REALLY don't allow browser docks to arbitrarily close OBS

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -395,6 +395,19 @@ bool QCefBrowserClient::OnContextMenuCommand(
 	return false;
 }
 
+void QCefBrowserClient::OnLoadStart(CefRefPtr<CefBrowser>,
+				    CefRefPtr<CefFrame> frame, TransitionType)
+{
+	if (!frame->IsMain())
+		return;
+
+	std::string script = "window.close = () => ";
+	script += "console.log(";
+	script += "'OBS browser docks cannot be closed using JavaScript.'";
+	script += ");";
+	frame->ExecuteJavaScript(script, "", 0);
+}
+
 void QCefBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>,
 				  CefRefPtr<CefFrame> frame, int)
 {
@@ -405,12 +418,6 @@ void QCefBrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>,
 		frame->ExecuteJavaScript(widget->script, CefString(), 0);
 	else if (!script.empty())
 		frame->ExecuteJavaScript(script, CefString(), 0);
-
-	std::string script2 = "window.close = () => ";
-	script2 += "console.log(";
-	script2 += "'OBS browser docks cannot be closed using JavaScript.'";
-	script2 += ");";
-	frame->ExecuteJavaScript(script2, "", 0);
 }
 
 bool QCefBrowserClient::OnJSDialog(CefRefPtr<CefBrowser>, const CefString &,

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -95,6 +95,10 @@ public:
 		CefContextMenuHandler::EventFlags event_flags) override;
 
 	/* CefLoadHandler */
+	virtual void OnLoadStart(CefRefPtr<CefBrowser> browser,
+				 CefRefPtr<CefFrame> frame,
+				 TransitionType transition_type) override;
+
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,
 			       CefRefPtr<CefFrame> frame,
 			       int httpStatusCode) override;


### PR DESCRIPTION

### Description

* See #427

### Motivation and Context

The previous solution only worked for code that ran after the page had *finished* loading. I was hoping that'd solve the problem for most users, which it didn't. But even if it did, we still don't want browser docks to be able to arbitrarily close the main OBS window.

* See #427

### How Has This Been Tested?

Implement a page that calls `window.close()` immediately.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
