### PR TITLE
Enable building with CEF 6261 & 6367 (Chromium 122 & 124)

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -147,7 +147,12 @@ void BrowserApp::ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
 	std::vector<CefString> names;
 	browser->GetFrameNames(names);
 	for (auto &name : names) {
-		CefRefPtr<CefFrame> frame = browser->GetFrame(name);
+		CefRefPtr<CefFrame> frame =
+#if CHROME_VERSION_BUILD >= 6261
+			browser->GetFrameByName(name);
+#else
+			browser->GetFrame(name);
+#endif
 		CefRefPtr<CefV8Context> context = frame->GetV8Context();
 
 		context->Enter();
@@ -346,7 +351,12 @@ bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 		std::vector<CefString> names;
 		browser->GetFrameNames(names);
 		for (auto &name : names) {
-			CefRefPtr<CefFrame> frame = browser->GetFrame(name);
+			CefRefPtr<CefFrame> frame =
+#if CHROME_VERSION_BUILD >= 6261
+				browser->GetFrameByName(name);
+#else
+				browser->GetFrame(name);
+#endif
 			CefRefPtr<CefV8Context> context = frame->GetV8Context();
 
 			context->Enter();

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -517,7 +517,11 @@ void ProcessCef()
 
 #define MAX_DELAY (1000 / 30)
 
+#if CHROME_VERSION_BUILD < 5938
 void BrowserApp::OnScheduleMessagePumpWork(int64 delay_ms)
+#else
+void BrowserApp::OnScheduleMessagePumpWork(int64_t delay_ms)
+#endif
 {
 	if (delay_ms < 0)
 		delay_ms = 0;

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -110,7 +110,11 @@ public:
 			     CefString &exception) override;
 
 #ifdef ENABLE_BROWSER_QT_LOOP
+#if CHROME_VERSION_BUILD < 5938
 	virtual void OnScheduleMessagePumpWork(int64 delay_ms) override;
+#else
+	virtual void OnScheduleMessagePumpWork(int64_t delay_ms) override;
+#endif
 	QTimer frameTimer;
 #endif
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -135,10 +135,14 @@ public:
 			     const void *buffer, int width,
 			     int height) override;
 #ifdef ENABLE_BROWSER_SHARED_TEXTURE
-	virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,
-					PaintElementType type,
-					const RectList &dirtyRects,
-					void *shared_handle) override;
+	virtual void
+	OnAcceleratedPaint(CefRefPtr<CefBrowser> browser, PaintElementType type,
+			   const RectList &dirtyRects,
+#if CHROME_VERSION_BUILD >= 6367
+			   const CefAcceleratedPaintInfo &info) override;
+#else
+			   void *shared_handle) override;
+#endif
 #ifdef CEF_ON_ACCELERATED_PAINT2
 	virtual void OnAcceleratedPaint2(CefRefPtr<CefBrowser> browser,
 					 PaintElementType type,

--- a/obs-browser-page/obs-browser-page-main.cpp
+++ b/obs-browser-page/obs-browser-page-main.cpp
@@ -79,8 +79,10 @@ int CALLBACK WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	std::thread shutdown_check;
 
 	CefMainArgs mainArgs(nullptr);
+#if CHROME_VERSION_BUILD < 5615
 	if (!SetHighDPIv2Scaling())
 		CefEnableHighDPISupport();
+#endif
 
 	CefRefPtr<CefCommandLine> command_line =
 		CefCommandLine::CreateCommandLine();

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -748,9 +748,12 @@ bool obs_module_load(void)
 
 	os_event_init(&cef_started_event, OS_EVENT_TYPE_MANUAL);
 
-#ifdef _WIN32
+#if defined(_WIN32) && CHROME_VERSION_BUILD < 5615
 	/* CefEnableHighDPISupport doesn't do anything on OS other than Windows. Would also crash macOS at this point as CEF is not directly linked */
 	CefEnableHighDPISupport();
+#endif
+
+#ifdef _WIN32
 	EnumAdapterCount();
 #else
 #if defined(__APPLE__) && !defined(ENABLE_BROWSER_LEGACY)

--- a/obs-browser-source.cpp
+++ b/obs-browser-source.cpp
@@ -658,7 +658,7 @@ extern void ProcessCef();
 void BrowserSource::Render()
 {
 	bool flip = false;
-#ifdef ENABLE_BROWSER_SHARED_TEXTURE
+#if defined(ENABLE_BROWSER_SHARED_TEXTURE) && CHROME_VERSION_BUILD < 6367
 	flip = hwaccel;
 #endif
 


### PR DESCRIPTION
### Description

This allows compiling OBS Browser with Chromium 124-based CEF versions.

This also adds basic support for the new, official, shared textures API on both Windows and macOS.

Sources:
 - https://github.com/chromiumembedded/cef/blame/d3a483ef59f8f40c624967361e05edda413bbf5b/libcef_dll/ctocpp/browser_ctocpp.h#L57
 - https://bitbucket.org/chromiumembedded/cef/commits/f3b570c
 - https://bitbucket.org/chromiumembedded/cef/commits/260dd0ca2

Fun note; Remote debugging now requires `--remote-allow-origins=*` otherwise Remote Debugging immediately disconnects - even for localhost.

### Motivation and Context

At some point we'd like to upgrade to modern CEF. To do that, obs-browser needs to compile.

### How Has This Been Tested?

Launch OBS with a CEF 6261 or 6367 build. Have not tested downgrading CEF to our currently supported versions.

Only tested on Windows.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
