### PR TITLE
cmake: Set minimum CEF version to 95

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT ENABLE_BROWSER)
   return()
 endif()
 
-find_package(CEF REQUIRED)
+find_package(CEF REQUIRED 95)
 find_package(nlohmann_json REQUIRED)
 
 add_library(obs-browser MODULE)

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -25,7 +25,7 @@ option(ENABLE_BROWSER_QT_LOOP "Enable running CEF on the main UI thread alongsid
 
 mark_as_advanced(ENABLE_BROWSER_LEGACY ENABLE_BROWSER_SHARED_TEXTURE ENABLE_BROWSER_PANELS ENABLE_BROWSER_QT_LOOP)
 
-find_package(CEF REQUIRED)
+find_package(CEF REQUIRED 95)
 
 if(NOT TARGET CEF::Wrapper)
   message(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
We know that our minimum supported CEF version is 95, and we know that OBS (or obs-browser) will fail to build against anything older. Specify the minimum version required in CMake so this becomes a configure failure instead of a build failure.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes https://github.com/obsproject/obs-studio/issues/7963.

Actually fixing on the obs-studio side will require a submodule update.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I configured obs-studio on Windows 11 with CEF 103.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
