### PR TITLE
Add function to call websocket request from JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,31 @@ Permissions required: ALL
 window.obsstudio.stopVirtualcam()
 ```
 
+#### Call Websocket request
+Permissions required: ALL
+```js
+/**
+ * @typedef {Object} WebsocketResponse
+ * @property {number} code - RequestStatus code
+ * @property {bool} result - is true if the request resulted in Success. False if otherwise.
+ * @property {string} responseData - JSON string containing response data
+ * @property {string} comment - may be provided by the server on errors to offer further details on why a request failed.
+ */
+
+/**
+ * @callback WebsocketRequestCallback
+ * @param {WebsocketResponse} response
+ */
+
+/**
+ * @param {WebsocketRequestCallback} cb
+ * @param {string} request_type - The request type to call
+ * @param {string} request_data - JSON string containing appropriate request data
+ */
+window.obsstudio.callWebsocketRequest(function (response_data) {
+    console.log(JSON.stringify(response))
+}, request_type, request_data)
+```
 
 ### Register for visibility callbacks
 

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -100,13 +100,13 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 }
 
 std::vector<std::string> exposedFunctions = {
-	"getControlLevel",     "getCurrentScene",  "getStatus",
-	"startRecording",      "stopRecording",    "startStreaming",
-	"stopStreaming",       "pauseRecording",   "unpauseRecording",
-	"startReplayBuffer",   "stopReplayBuffer", "saveReplayBuffer",
-	"startVirtualcam",     "stopVirtualcam",   "getScenes",
-	"setCurrentScene",     "getTransitions",   "getCurrentTransition",
-	"setCurrentTransition"};
+	"getControlLevel",      "getCurrentScene",     "getStatus",
+	"startRecording",       "stopRecording",       "startStreaming",
+	"stopStreaming",        "pauseRecording",      "unpauseRecording",
+	"startReplayBuffer",    "stopReplayBuffer",    "saveReplayBuffer",
+	"startVirtualcam",      "stopVirtualcam",      "getScenes",
+	"setCurrentScene",      "getTransitions",      "getCurrentTransition",
+	"setCurrentTransition", "callWebsocketRequest"};
 
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
 				  CefRefPtr<CefFrame>,

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -19,6 +19,7 @@
 #include "browser-client.hpp"
 #include "obs-browser-source.hpp"
 #include "base64/base64.hpp"
+#include "..\obs-websocket\lib\obs-websocket-api.h"
 #include <nlohmann/json.hpp>
 #include <obs-frontend-api.h>
 #include <obs.hpp>
@@ -142,6 +143,28 @@ bool BrowserClient::OnProcessMessageReceived(
 			obs_frontend_start_virtualcam();
 		} else if (name == "stopVirtualcam") {
 			obs_frontend_stop_virtualcam();
+		} else if (name == "callWebsocketRequest") {
+			std::string request_type =
+				input_args->GetString(1).ToString();
+			std::string request_data_string =
+				input_args->GetString(2).ToString();
+			OBSDataAutoRelease request_data =
+				obs_data_create_from_json(
+					request_data_string.c_str());
+			struct obs_websocket_request_response *response =
+				obs_websocket_call_request(request_type.c_str(),
+							   request_data);
+			if (response) {
+				json = {{"code", response->status_code},
+					{"result",
+					 response->status_code == 100}};
+				if (response->response_data)
+					json["responseData"] =
+						response->response_data;
+				if (response->comment)
+					json["comment"] = response->comment;
+				obs_websocket_request_response_free(response);
+			}
 		}
 		[[fallthrough]];
 	case ControlLevel::Advanced:


### PR DESCRIPTION
### Description
Add function to call websocket request from JavaScript
This will require page permission full access

### Motivation and Context
This makes browser source pages not having to setup a websocket connection to call websocket requests.
Other alternative to #439 and #423

### How Has This Been Tested?
On windows 11

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
