### PR TITLE
Set the right Ozone platform on Linux

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -96,6 +96,9 @@ void BrowserApp::OnBeforeCommandLineProcessing(
 					    "no-user-gesture-required");
 #ifdef __APPLE__
 	command_line->AppendSwitch("use-mock-keychain");
+#elif !defined(_WIN32)
+	command_line->AppendSwitchWithValue("ozone-platform",
+					    wayland ? "wayland" : "x11");
 #endif
 }
 

--- a/browser-app.hpp
+++ b/browser-app.hpp
@@ -77,10 +77,20 @@ class BrowserApp : public CefApp,
 	bool shared_texture_available;
 	CallbackMap callbackMap;
 	int callbackId;
+#if !defined(__APPLE__) && !defined(_WIN32)
+	bool wayland;
+#endif
 
 public:
+#if defined(__APPLE__) || defined(_WIN32)
 	inline BrowserApp(bool shared_texture_available_ = false)
 		: shared_texture_available(shared_texture_available_)
+#else
+	inline BrowserApp(bool shared_texture_available_ = false,
+			  bool wayland_ = false)
+		: shared_texture_available(shared_texture_available_),
+		  wayland(wayland_)
+#endif
 	{
 	}
 

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -46,6 +46,10 @@
 #include "signal-restore.hpp"
 #endif
 
+#ifdef ENABLE_WAYLAND
+#include <obs-nix-platform.h>
+#endif
+
 #ifdef ENABLE_BROWSER_QT_LOOP
 #include <QApplication>
 #include <QThread>
@@ -386,7 +390,13 @@ static void BrowserInit(void)
 	}
 #endif
 
+#if defined(__APPLE__) || defined(_WIN32) || !defined(ENABLE_WAYLAND)
 	app = new BrowserApp(tex_sharing_avail);
+#else
+	app = new BrowserApp(tex_sharing_avail,
+			     obs_get_nix_platform() ==
+				     OBS_NIX_PLATFORM_WAYLAND);
+#endif
 
 #ifdef _WIN32
 	CefExecuteProcess(args, app, nullptr);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes https://github.com/obsproject/obs-studio/issues/11019

Forcing CEF to use the right Ozone platform allows to avoid having a dependency on XWayland (a X11 socket) under Wayland.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Chromium still does not default to the matching platform, but in our use of CEF we need CEF to use the same platform at Qt/OBS

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Ran the Flatpak without any X11 permission and added a browser source, no crash occurs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
