### PR TITLE
Fix CSS injection for sites with 'require-trusted-types-for'

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -679,8 +679,9 @@ void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame,
 
 		std::string script;
 		script += "const obsCSS = document.createElement('style');";
-		script += "obsCSS.innerHTML = decodeURIComponent(\"" +
-			  uriEncodedCSS + "\");";
+		script += "obsCSS.appendChild(document.createTextNode("
+			  "decodeURIComponent(\"" +
+			  uriEncodedCSS + "\")));";
 		script += "document.querySelector('head').appendChild(obsCSS);";
 
 		frame->ExecuteJavaScript(script, "", 0);


### PR DESCRIPTION
### Description
This pull request modifies the CSS injection method in the OBS source code. Specifically, it replaces the use of `innerHTML` with `createTextNode` for inserting styles. This change allows the CSS injection to work properly on websites with strict Content Security Policy (CSP) that includes Trusted Types enforcement.

### Motivation and Context
On certain websites, particularly those with strict CSP including `require-trusted-types-for 'script'`, our previous CSS injection method failed. This resulted in a TypeError:

"This document requires 'TrustedHTML' assignment. Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment."

![resnponse_header_content-security-policy](https://github.com/user-attachments/assets/8a253071-cc00-4260-aeed-26372b84a8f3)
![obs_css_not_applied](https://github.com/user-attachments/assets/f4d8d91e-a686-471a-b166-321faceaf3af)

This change is required to ensure OBS functions correctly across a wider range of websites, including those with stringent security policies.

### How Has This Been Tested?
- Windows 11 x64
- YouTube live chat pages (https://www.youtube.com/live_chat?v=*****) where the response header includes 
`content-security-policy: require-trusted-types-for 'script'`
  - I used CSS from https://chatv2.septapus.com/
  - This seems to occur only for some accounts, not all users.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.