### PR TITLE
Wait on shutdown for docks to close on Linux ('simplest' solution)

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -181,6 +181,12 @@ void QCefWidgetInternal::closeBrowser()
 			}
 
 			cefBrowser->GetHost()->CloseBrowser(true);
+
+#if !defined(_WIN32) && !defined(__APPLE__) && CHROME_VERSION_BUILD >= 6533
+			while (cefBrowser && cefBrowser->IsValid()) {
+				os_sleep_ms(10);
+			}
+#endif
 		};
 
 		/* So you're probably wondering what's going on here.  If you


### PR DESCRIPTION
### Description

Fixes a 100% reproducible crash on shutdown when running Chromium 127.

This is likely the same crash users have been running into with current CEF with a lower hit rate.

This is a temporary/simplified solution to allow a quick CEF upgrade.

Ideally we should track open docks & count `OnBeforeClose` calls before fully closing, per CEF documentation.

> The [CefLifeSpanHandler::OnBeforeClose()](https://cef-builds.spotifycdn.com/docs/127.0/classCefLifeSpanHandler.html#af79cf13d98aacb59618dbbe273cce0fa) method will be called after [DoClose()](https://cef-builds.spotifycdn.com/docs/127.0/classCefLifeSpanHandler.html#a4867b3d97d879d9996dec2cf1daa483d) (if [DoClose()](https://cef-builds.spotifycdn.com/docs/127.0/classCefLifeSpanHandler.html#a4867b3d97d879d9996dec2cf1daa483d) is called) and immediately before the browser object is destroyed. **The application should only exit after [OnBeforeClose()](https://cef-builds.spotifycdn.com/docs/127.0/classCefLifeSpanHandler.html#af79cf13d98aacb59618dbbe273cce0fa) has been called for all existing browsers.**

The same fix does not seem to be needed for browser sources, likely because they're closed earlier in the shutdown flow.

### Motivation and Context

Crashes are bad, including on shutdown.

### How Has This Been Tested?

Ubuntu 24.04.

* 1 dock (Google):   waits 30ms
* 1 dock (YouTube): waits 100ms
* 2 docks (Google + YouTube)):   waits 150ms

Without this fix, using a DCHECK enabled CEF build to read the error message:

```
[0818/184348.915859:FATAL:alloy_browser_main.cc(417)] Check failed: global_request_context_->HasOneRef(). 
```

With additional logging in OBS, the culprit was identified as Qt not waiting long enough for browser docks to close.
Good browser dock close (such as closing a single dock with its X):
```
warning: QCefWidgetInternal::~closeBrowser ---- starting
warning: QCefWidgetInternal::~closeBrowser ---- destroyed
warning: QCefWidgetInternal::~closeBrowser ---- ended
warning: ~QCefBrowserClient() ---- destroyed
```
Bad browser dock close (closing the app while browser docks are loaded):
```
warning: QCefWidgetInternal::~closeBrowser ---- starting
warning: QCefWidgetInternal::~closeBrowser ---- destroyed
warning: QCefWidgetInternal::~closeBrowser ---- ended
warning: QCefWidgetInternal::~QCefWidgetInternal ---- closed
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
