### PR TITLE
Trivial: Add version requirement for nlohmann/json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT ENABLE_BROWSER)
 endif()
 
 find_package(CEF REQUIRED 95)
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json 3.11 REQUIRED)
 
 add_library(obs-browser MODULE)
 add_library(OBS::browser ALIAS obs-browser)


### PR DESCRIPTION
### Description

Adds a version requirement for nlohmann/json to `find_package` call in `CMakeLists.txt`.


### Motivation and Context

obs-browser requires nlohmann/json >= 3.11 due to the use of  *_WITH_DEFAULT macros, which are not defined in earlier versions.


### How Has This Been Tested?

Tested on UbuntuMATE 22.04, g++12.

-   nlohmann/json built and installed from source;
-   used backport of ffmpeg 6 from ppa.


### Types of changes

Build improvement: Makes it easier to identify problems when nlohmann < 3.11 installed - likely not critical as e.g. linux distros with ffmpeg6 in APT almost always have nlohmann >= 3.11; but 22.04 (for example) does not.


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
