### PR TITLE
Wait on shutdown for docks to close on Linux (Event-based solution)

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -213,6 +213,13 @@ bool QCefBrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>
 	return true;
 }
 
+void QCefBrowserClient::OnBeforeClose(CefRefPtr<CefBrowser>)
+{
+	if (widget) {
+		emit widget->CloseSafely();
+	}
+}
+
 bool QCefBrowserClient::OnSetFocus(CefRefPtr<CefBrowser>, CefFocusHandler::FocusSource source)
 {
 	/* Don't steal focus when the webpage navigates. This is especially

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -57,6 +57,8 @@ public:
 				   CefRefPtr<CefClient> &client, CefBrowserSettings &settings,
 				   CefRefPtr<CefDictionaryValue> &extra_info, bool *no_javascript_access) override;
 
+	virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+
 	/* CefFocusHandler */
 	virtual bool OnSetFocus(CefRefPtr<CefBrowser> browser, CefFocusHandler::FocusSource source) override;
 

--- a/panel/browser-panel-internal.hpp
+++ b/panel/browser-panel-internal.hpp
@@ -51,6 +51,7 @@ public:
 	virtual bool zoomPage(int direction) override;
 	virtual void executeJavaScript(const std::string &script) override;
 
+	void CloseSafely();
 	void Resize();
 
 #ifdef __linux__
@@ -61,4 +62,7 @@ private:
 
 public slots:
 	void Init();
+
+signals:
+	void readyToClose();
 };


### PR DESCRIPTION
### Description

Solution 1 was a no-go with the Qt event loop, which we'd prefer to use.

This is solution two, which listens for an event from CEF when the shutdown is occurring. At most, it's configured to wait 1 second per dock (this is usually more than enough time, but we could bump it to 2 or 3 if needed).

This also moves widget destruction to *after* Qt destruction, otherwise CEF can't notify Qt that it's ready to close.

Also Closes #459

### Motivation and Context

The original solution in #450 works fine when not using the Qt event loop, however any method of waiting with the Qt event loop causes all CEF events to go on hold too, resulting in a hang or crash.

### How Has This Been Tested?

On Linux, with two browser docks: YouTube and Google. The former is considered a "heavier" dock and takes longer to close.

Also successfully loaded the Twitch OAuth window.

Tested with our current Beta 1-shipping CEF build of 127.

With this PR, there is no crash or hang on shutdown.

Note: Have not tested "What's New" myself.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
