### PR TITLE
Log fatal CEF crashes to file

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -281,7 +281,7 @@ static void BrowserInit(void)
 	os_mkdir(conf_path);
 
 	CefSettings settings;
-	settings.log_severity = LOGSEVERITY_DISABLE;
+	settings.log_severity = LOGSEVERITY_FATAL;
 	BPtr<char> log_path = obs_module_config_path("debug.log");
 	BPtr<char> log_path_abs = os_get_abs_path_ptr(log_path);
 	CefString(&settings.log_file) = log_path_abs;


### PR DESCRIPTION
### Description

CEF provides no method to reroute logging, but without FATAL logging it is impossible to track down some crashes.

This outputs FATAL-level logging to `debug.log` in the obs-browser user data directory.

### Motivation and Context

We don't ship CEF symbols so some crashes become impossible to track down. By logging fatal errors, we can get some insight.

### How Has This Been Tested?

Launched OBS on Windows. Verified the `debug.log` contained an error after a crash.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
