### PR TITLE
Expand panel shutdown event listener to all platforms

### DIFF
--- a/panel/browser-panel.cpp
+++ b/panel/browser-panel.cpp
@@ -166,7 +166,7 @@ void QCefWidgetInternal::closeBrowser()
 
 			cefBrowser->GetHost()->CloseBrowser(true);
 
-#if !defined(_WIN32) && !defined(__APPLE__) && CHROME_VERSION_BUILD >= 6533
+#if CHROME_VERSION_BUILD >= 6533
 			QEventLoop loop;
 
 			connect(this, &QCefWidgetInternal::readyToClose, &loop, &QEventLoop::quit);


### PR DESCRIPTION
### Description

This expands the previously introduced shutdown loop check for browser docks to Windows and macOS.

As a reminder, this solves a potential crash on shutdown if the user has many docks or heavy docks.

As this solution has a timeout (max 1 second per dock), I am much more comfortable expanding its usage to all platforms compared to the original solution.

### Motivation and Context

I have a feeling that users on other platforms have been running into this issue, but because we don't provide CEF symbols (and because it occurs on shutdown) reports have been sporadic and/or lacking the necessary detail to track it down.

### How Has This Been Tested?

Close browser docks manually and on shutdown, experience no crash.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.