### PR TITLE
Fix controller detection on Windows 11 by disabling modern game controller API

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -78,10 +78,16 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 		// Don't override existing, as this can break OSR
 		std::string disableFeatures = command_line->GetSwitchValue("disable-features");
 		disableFeatures += ",HardwareMediaKeyHandling";
+#ifdef _WIN32
+		disableFeatures += ",EnableWindowsGamingInputDataFetcher";
+#endif
 		disableFeatures += ",WebBluetooth";
 		command_line->AppendSwitchWithValue("disable-features", disableFeatures);
 	} else {
 		command_line->AppendSwitchWithValue("disable-features", "WebBluetooth,"
+#ifdef _WIN32
+									"EnableWindowsGamingInputDataFetcher,"
+#endif
 									"HardwareMediaKeyHandling");
 	}
 


### PR DESCRIPTION
### Description

Chromium 117 and above uses [Windows.Gaming.Input](https://learn.microsoft.com/en-us/uwp/api/windows.gaming.input?view=winrt-26100), which states
> ## Remarks
> A Windows application must have focus to receive input from a controller.

This is not useful, as users will have the game focused, not OBS.

Issue raised with Chromium: https://issues.chromium.org/issues/392661398
Original commit that introduced the change:
https://chromiumdash.appspot.com/commit/aeb76145fe766a359f2e2b7432c207cc135113b6

The mentioned flag is set to never expire, so should be available indefinitely.

Ideally, Microsoft should update this API to match the previous (XInput) behaviour, or provide a flag to set the focus policy, which *is* provided by the [IGameInput API](https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/reference/input/gameinput/interfaces/igameinput/methods/igameinput_setfocuspolicy). Until then, we will disable WGI.

### Motivation and Context

Ultimately, this is a regression. Multiple users have reported being unable to use Gamepad Viewer when using Windows 11 and OBS 31. This is a very common use case of displaying controller inputs on stream.

### How Has This Been Tested?

* Launch OBS on Windows 11
* Add a browser source pointing to https://hardwaretester.com/gamepad
* Push buttons
* Unfocus OBS window
* Push more buttons

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
