### PR TITLE
Enable building with CEF 6834 (Chromium 132) and 6943 (133)

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -276,6 +276,11 @@ CefRefPtr<CefV8Value> CefValueToCefV8Value(CefRefPtr<CefValue> value)
 			result->SetValue((int)i, CefValueToCefV8Value(list->GetValue(i)));
 		}
 	} break;
+#if !defined(_WIN32) && CHROME_VERSION_BUILD >= 6943
+	case VTYPE_NUM_VALUES:
+		result = CefV8Value::CreateNull();
+		break;
+#endif
 	}
 	return result;
 }

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -99,9 +99,13 @@ CefResourceRequestHandler::ReturnValue BrowserClient::OnBeforeResourceLoad(CefRe
 }
 #endif
 
-bool BrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>, const CefString &, const CefString &,
-				  cef_window_open_disposition_t, bool, const CefPopupFeatures &, CefWindowInfo &,
-				  CefRefPtr<CefClient> &, CefBrowserSettings &, CefRefPtr<CefDictionaryValue> &, bool *)
+bool BrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
+#if CHROME_VERSION_BUILD >= 6834
+				  int,
+#endif
+				  const CefString &, const CefString &, cef_window_open_disposition_t, bool,
+				  const CefPopupFeatures &, CefWindowInfo &, CefRefPtr<CefClient> &,
+				  CefBrowserSettings &, CefRefPtr<CefDictionaryValue> &, bool *)
 {
 	/* block popups */
 	return true;

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -87,6 +87,9 @@ public:
 
 	/* CefLifeSpanHandler */
 	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+#if CHROME_VERSION_BUILD >= 6834
+				   int popup_id,
+#endif
 				   const CefString &target_url, const CefString &target_frame_name,
 				   cef_window_open_disposition_t target_disposition, bool user_gesture,
 				   const CefPopupFeatures &popupFeatures, CefWindowInfo &windowInfo,

--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -34,6 +34,9 @@
 #include <include/cef_parser.h>
 #include <include/cef_scheme.h>
 #include <include/cef_version.h>
+#if CHROME_VERSION_BUILD >= 6943
+#include <include/cef_version_info.h>
+#endif
 #include <include/cef_render_process_handler.h>
 #include <include/cef_request_context_handler.h>
 #include <include/cef_jsdialog_handler.h>

--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -172,10 +172,14 @@ void QCefBrowserClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 }
 
 /* CefLifeSpanHandler */
-bool QCefBrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>, const CefString &target_url,
-				      const CefString &, CefLifeSpanHandler::WindowOpenDisposition, bool,
-				      const CefPopupFeatures &, CefWindowInfo &windowInfo, CefRefPtr<CefClient> &,
-				      CefBrowserSettings &, CefRefPtr<CefDictionaryValue> &, bool *)
+bool QCefBrowserClient::OnBeforePopup(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
+#if CHROME_VERSION_BUILD >= 6834
+				      int,
+#endif
+				      const CefString &target_url, const CefString &,
+				      CefLifeSpanHandler::WindowOpenDisposition, bool, const CefPopupFeatures &,
+				      CefWindowInfo &windowInfo, CefRefPtr<CefClient> &, CefBrowserSettings &,
+				      CefRefPtr<CefDictionaryValue> &, bool *)
 {
 	if (allowAllPopups) {
 #ifdef _WIN32

--- a/panel/browser-panel-client.hpp
+++ b/panel/browser-panel-client.hpp
@@ -51,6 +51,9 @@ public:
 
 	/* CefLifeSpanHandler */
 	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+#if CHROME_VERSION_BUILD >= 6834
+				   int popup_id,
+#endif
 				   const CefString &target_url, const CefString &target_frame_name,
 				   CefLifeSpanHandler::WindowOpenDisposition target_disposition, bool user_gesture,
 				   const CefPopupFeatures &popupFeatures, CefWindowInfo &windowInfo,


### PR DESCRIPTION
### Description

OnBeforePopup gained a `popup_id`. No other changes required.

https://cef-builds.spotifycdn.com/docs/132.0/classCefLifeSpanHandler.html

Note: This does not open the door for us to upgrade to Chromium 128 or above just yet, as that still requires locking down the Chromium framework.

### Motivation and Context

To make testing newer CEF builds easier. Especially as we're trying to debug [the 250ms freeze](https://github.com/obsproject/obs-browser/issues/468), which we might have [a potential fix](https://chromium-review.googlesource.com/c/chromium/src/+/6232721) for (and, if all goes well, we can backport to CEF 6533).

### How Has This Been Tested?

* Download a minimal 132 build from https://cef-builds.spotifycdn.com/index.html
* Build the CEF wrapper (with `USE_SANDBOX` off)
* Build OBS with the CEF build
* Verify OBS launches

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
