### PR TITLE
Print basic browser source rendering crashes to OBS log

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -83,6 +83,14 @@ CefRefPtr<CefResourceRequestHandler> BrowserClient::GetResourceRequestHandler(Ce
 	return nullptr;
 }
 
+void BrowserClient::OnRenderProcessTerminated(CefRefPtr<CefBrowser>, TerminationStatus, int,
+					      const CefString &error_string)
+{
+	std::string str_text = error_string;
+	blog(LOG_ERROR, "[obs-browser: '%s'] Webpage has crashed unexpectedly! Reason: '%s'",
+	     obs_source_get_name(bs->source), str_text.c_str());
+}
+
 CefResourceRequestHandler::ReturnValue BrowserClient::OnBeforeResourceLoad(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
 									   CefRefPtr<CefRequest>,
 									   CefRefPtr<CefCallback>)

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -98,6 +98,8 @@ public:
 	GetResourceRequestHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 				  CefRefPtr<CefRequest> request, bool is_navigation, bool is_download,
 				  const CefString &request_initiator, bool &disable_default_handling) override;
+	virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status, int error_code,
+					       const CefString &error_string) override;
 
 	/* CefResourceRequestHandler */
 	virtual CefResourceRequestHandler::ReturnValue OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser,


### PR DESCRIPTION
### Description

While we cannot route most CEF/Chromium logging, we can catch rendering crashes and log them ourselves.

Docs: https://cef-builds.spotifycdn.com/docs/127.0/classCefRequestHandler.html#a6998e9b6ee7b0e9a810567fad3a6b4ea

Wording improvements welcome.

Example using `chrome://crash/`:

```
22:19:49.388: [obs-browser: 'Crash page'] Webpage has crashed unexpectedly! Reason: 'STATUS_ACCESS_VIOLATION'
```

Wasn't sure whether I should implement the same for browser docks. If others believe it's worth doing, I can make that change too.

### Motivation and Context

While looking into ways to log iframe crashes, I came across this function which provides insight into browser renderer crashes. While this function doesn't seem to run for the specific crash a user experienced, I felt it was a useful case to handle.

### How Has This Been Tested?

- Add a browser source
- Set it to `chrome://crash/`
- See the entry in the log

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
