### PR TITLE
Don't loop CEF exit while shutting down if task post fails

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -774,8 +774,8 @@ void obs_module_unload(void)
 	BrowserShutdown();
 #else
 	if (manager_thread.joinable()) {
-		while (!QueueCEFTask([]() { CefQuitMessageLoop(); }))
-			os_sleep_ms(5);
+		if (!QueueCEFTask([]() { CefQuitMessageLoop(); }))
+			blog(LOG_DEBUG, "[obs-browser]: Failed to post CefQuit task to loop");
 
 		manager_thread.join();
 	}


### PR DESCRIPTION
### Description
Removes a while loop which loops infinitely if posting the shutdown task to the manager thread fails. In scenarios where Cef failed to initialize, this manager thread exits early, leaving a situation where tasks *cannot be posted to it.* In normal scenarios, posting the task is not expected to fail anyway.

This also logs a debug message just in case it becomes relevant in the future.

### Motivation and Context
If the `manager_thread` exits early, there will be no message loop to post the task to, and a permanent deadlock would occur. 

Rather than guaranteeing a deadlock, this at least lowers the odds of one.

### How Has This Been Tested?
- Ubuntu 24.04 - X11 on NVIDIA
- Tested a standard working configuration where browsers load and then OBS is closed gracefully
- Tested a non-working configuration where CEF fails to initialize due to an invalid SingletonCookie

All test scenarios exited gracefully without deadlocking.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
