### PR TITLE
Log error if CefInitialize fails

### DIFF
--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -367,10 +367,10 @@ static void BrowserInit(void)
 
 #if !defined(_WIN32)
 	BackupSignalHandlers();
-	CefInitialize(args, settings, app, nullptr);
+	bool success = CefInitialize(args, settings, app, nullptr);
 	RestoreSignalHandlers();
 #elif (CHROME_VERSION_BUILD > 3770)
-	CefInitialize(args, settings, app, nullptr);
+	bool success = CefInitialize(args, settings, app, nullptr);
 #else
 	/* Massive (but amazing) hack to prevent chromium from modifying our
 	 * process tokens and permissions, which caused us problems with winrt,
@@ -379,8 +379,13 @@ static void BrowserInit(void)
 	 * we'll just switch back to the static library but I doubt we'll need
 	 * to. */
 	uintptr_t zeroed_memory_lol[32] = {};
-	CefInitialize(args, settings, app, zeroed_memory_lol);
+	bool success = CefInitialize(args, settings, app, zeroed_memory_lol);
 #endif
+
+	if (!success) {
+		blog(LOG_ERROR, "[obs-browser]: CEF failed to initialize. Exit code: %d", CefGetExitCode());
+		return;
+	}
 
 #if !ENABLE_LOCAL_FILE_URL_SCHEME
 	/* Register http://absolute/ scheme handler for older


### PR DESCRIPTION
### Description
If CefInitialize() fails, blogs an error so that people who actually pay attention to logs can understand why browser sources are not working.

More work should be done to fully lock out the plugin if CefInitialize fails. Such behavior is required according to the CEF documentation.

See the CEF cef_resultcode_t enum for the definition of the exit codes.

### Motivation and Context
So it turns out CefInitialize is a boolean return... Anyway, let's log failures so that we can at least begin to track them down. This change also returns early, but that does not make any of what we're doing any safer. Returning early currently only has the effect of safely disabling browser panels.

### How Has This Been Tested?
Compiles, and OBS doesn't immediately crash.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
