### PR TITLE
Check source validity before attempting to log renderer crash

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -86,9 +86,18 @@ CefRefPtr<CefResourceRequestHandler> BrowserClient::GetResourceRequestHandler(Ce
 void BrowserClient::OnRenderProcessTerminated(CefRefPtr<CefBrowser>, TerminationStatus, int,
 					      const CefString &error_string)
 {
+	if (!valid())
+		return;
+
 	std::string str_text = error_string;
-	blog(LOG_ERROR, "[obs-browser: '%s'] Webpage has crashed unexpectedly! Reason: '%s'",
-	     obs_source_get_name(bs->source), str_text.c_str());
+
+	const char *sourceName = "<unknown>";
+
+	if (bs && bs->source)
+		sourceName = obs_source_get_name(bs->source);
+
+	blog(LOG_ERROR, "[obs-browser: '%s'] Webpage has crashed unexpectedly! Reason: '%s'", sourceName,
+	     str_text.c_str());
 }
 
 CefResourceRequestHandler::ReturnValue BrowserClient::OnBeforeResourceLoad(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,


### PR DESCRIPTION
### Description

Follow-up to #475 ensuring we don't crash of our own fault.

### Motivation and Context

Saw a user post a crash log pointing to this function. https://obsproject.com/logs/tnMygGKxcYJ3MdiB

### How Has This Been Tested?

Verify existing crash handling behaviour continues to work. Added additional checks to match other functions.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
