### PR TITLE
Fix support for building with CEF 5060

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -83,13 +83,21 @@ CefRefPtr<CefResourceRequestHandler> BrowserClient::GetResourceRequestHandler(Ce
 	return nullptr;
 }
 
-void BrowserClient::OnRenderProcessTerminated(CefRefPtr<CefBrowser>, TerminationStatus, int,
-					      const CefString &error_string)
+void BrowserClient::OnRenderProcessTerminated(CefRefPtr<CefBrowser>, TerminationStatus
+#if CHROME_VERSION_BUILD >= 6367
+					      ,
+					      int, const CefString &error_string
+#endif
+)
 {
 	if (!valid())
 		return;
 
+#if CHROME_VERSION_BUILD >= 6367
 	std::string str_text = error_string;
+#else
+	std::string str_text = "<unknown>";
+#endif
 
 	const char *sourceName = "<unknown>";
 

--- a/browser-client.hpp
+++ b/browser-client.hpp
@@ -98,8 +98,12 @@ public:
 	GetResourceRequestHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
 				  CefRefPtr<CefRequest> request, bool is_navigation, bool is_download,
 				  const CefString &request_initiator, bool &disable_default_handling) override;
-	virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status, int error_code,
-					       const CefString &error_string) override;
+	virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser, TerminationStatus status
+#if CHROME_VERSION_BUILD >= 6367
+					       ,
+					       int error_code, const CefString &error_string
+#endif
+					       ) override;
 
 	/* CefResourceRequestHandler */
 	virtual CefResourceRequestHandler::ReturnValue OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser,

--- a/obs-browser-plugin.cpp
+++ b/obs-browser-plugin.cpp
@@ -383,7 +383,11 @@ static void BrowserInit(void)
 #endif
 
 	if (!success) {
+#if CHROME_VERSION_BUILD >= 6367
 		blog(LOG_ERROR, "[obs-browser]: CEF failed to initialize. Exit code: %d", CefGetExitCode());
+#else
+		blog(LOG_ERROR, "[obs-browser]: CEF failed to initialize.");
+#endif
 		return;
 	}
 


### PR DESCRIPTION
### Description

Add a couple version checks for logging added in recent hotfixes to ensure continued compilation on the previously supported version of CEF.

Fixes #480 

### Motivation and Context

Generally, we aim to support the currently shipping CEF version and the previous (in this case 5060) to ensure easy verification of new issues with a current codebase (that is, easy downgrading for comparison), or to be able to easily revert in case of major bugs.

`CefGetExitCode()` did not exist until 124, and additional parameters were added to `OnRenderProcessTerminated`.

### How Has This Been Tested?

Toggle between CEF versions on Windows. Both compiled.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
