### PR TITLE
Add workaround for browser dock hanging

### DIFF
--- a/panel/browser-panel-client.cpp
+++ b/panel/browser-panel-client.cpp
@@ -226,6 +226,14 @@ void QCefBrowserClient::OnBeforeClose(CefRefPtr<CefBrowser>)
 
 bool QCefBrowserClient::OnSetFocus(CefRefPtr<CefBrowser>, CefFocusHandler::FocusSource source)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+	/* Workaround for browser docks flashing/hanging at startup with Qt 6.8.x, introduced
+	 * by commit https://code.qt.io/cgit/qt/qt5.git/commit/?id=bab1fecd556ea561c4a89686293116741acfa1b4.
+	 * Refer to https://bugreports.qt.io/browse/QTBUG-136165.
+	 */
+	UNUSED_PARAMETER(source);
+	return false;
+#else
 	/* Don't steal focus when the webpage navigates. This is especially
 	   obvious on startup when the user has many browser docks defined,
 	   as each one will steal focus one by one, resulting in poor UX.
@@ -236,6 +244,7 @@ bool QCefBrowserClient::OnSetFocus(CefRefPtr<CefBrowser>, CefFocusHandler::Focus
 	default:
 		return false;
 	}
+#endif
 }
 
 void QCefBrowserClient::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,


### PR DESCRIPTION
### Description

Create workaround for https://bugreports.qt.io/browse/QTBUG-136165. 

### Motivation and Context
Upcoming OBS Studio 31.1 release upgraded from Qt 6.6.3 to Qt 6.8.3. This upgrade revealed an incompatibility with browser docks and Qt 6.8.3. Specifically, when multiple browser docks were open, restarting OBS would often result in all docks flashing very quickly and eventually OBS would hang. This issue was always triggered when Twitch docks were enabled, which requires the appropriate Twitch authorization tokens during the build. Thankfully the TEB beta program caught this issue before OBS 31.1-beta1 was built so we had time to investigate.

### How Has This Been Tested?
Local testing with and without the fix in place. The underlying issue is very reproducible and the workaround so far has been 100% reliable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
