### PR TITLE
Require extra info for Linux hardware accel

### DIFF
--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -450,9 +450,9 @@ void BrowserClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType t
 #elif defined(_WIN32)
 	bs->texture = gs_texture_open_shared((uint32_t)(uintptr_t)shared_handle);
 #else
-	bs->texture = gs_texture_create_from_dmabuf(bs->width, bs->height, format.drm_format, format.gs_format,
-						    info.plane_count, fds, strides, offsets,
-						    modifier != DRM_FORMAT_MOD_INVALID ? modifiers : NULL);
+	bs->texture = gs_texture_create_from_dmabuf(info.extra.coded_size.width, info.extra.coded_size.height,
+						    format.drm_format, format.gs_format, info.plane_count, fds, strides,
+						    offsets, modifier != DRM_FORMAT_MOD_INVALID ? modifiers : NULL);
 #endif
 	UpdateExtraTexture();
 	obs_leave_graphics();

--- a/cef-headers.hpp
+++ b/cef-headers.hpp
@@ -50,7 +50,8 @@
 #define ENABLE_WASHIDDEN 0
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && CHROME_VERSION_BUILD > 6337
+#if !defined(_WIN32) && !defined(__APPLE__) && \
+	(CHROME_VERSION_BUILD >= 6943 || (CHROME_VERSION_BUILD > 6337 && defined(CEF_OSR_EXTRA_INFO)))
 #define ENABLE_BROWSER_SHARED_TEXTURE
 #endif
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Disable hardware accel on Linux if the extra field is not provided by CEF API.

A CEF 127 build with the API backported can be used if `CEF_OSR_EXTRA_INFO` is defined by the build itself. (https://github.com/tytan652/cef/tree/6533-fix-stutter-and-osr-extra-info)
Otherwise CEF 133 is required to enable it without backport required.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

To properly do DMA-BUF we need CEF to provide the size of the image and not rely on the source settings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It works on my machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
