### PR TITLE
Add get/set source visibility functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ window.obsstudio.getCurrentTransition(function (transition) {
 })
 ```
 
+#### Get source visibility
+Permissions required: READ_USER
+```js
+/**
+ * @callback VisibilityCallback
+ * @param {boolean} visibility - True -> visible, False -> hidden
+ */
+
+/**
+ * @param {string} scene - Name of the scene
+ * @param {string} source - Name of the source
+ * @param {VisibilityCallback} cb - The callback that receives the current visibility.
+ */
+window.obsstudio.getSourceVisible(scene, source, function (visibility) {
+    console.log(visibility)
+})
+```
+
 #### Save the Replay Buffer
 Permissions required: BASIC
 ```js
@@ -241,6 +259,17 @@ Permissions required: ADVANCED
  * @param {string} name - Name of the transition
  */
 window.obsstudio.setCurrentTransition(name)
+```
+
+#### Set source visibility
+Permissions required: ADVANCED
+```js
+/**
+ * @param {string} scene - Name of the scene
+ * @param {string} source - Name of the source
+ * @param {boolean} visibility - True -> visible, False -> hidden
+ */
+window.obsstudio.setSourceVisible(scene, source, visibility)
 ```
 
 #### Start streaming

--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -99,13 +99,13 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 #endif
 }
 
-std::vector<std::string> exposedFunctions = {"getControlLevel",     "getCurrentScene",  "getStatus",
-					     "startRecording",      "stopRecording",    "startStreaming",
-					     "stopStreaming",       "pauseRecording",   "unpauseRecording",
-					     "startReplayBuffer",   "stopReplayBuffer", "saveReplayBuffer",
-					     "startVirtualcam",     "stopVirtualcam",   "getScenes",
-					     "setCurrentScene",     "getTransitions",   "getCurrentTransition",
-					     "setCurrentTransition"};
+std::vector<std::string> exposedFunctions = {"getControlLevel",      "getCurrentScene",  "getStatus",
+					     "startRecording",       "stopRecording",    "startStreaming",
+					     "stopStreaming",        "pauseRecording",   "unpauseRecording",
+					     "startReplayBuffer",    "stopReplayBuffer", "saveReplayBuffer",
+					     "startVirtualcam",      "stopVirtualcam",   "getScenes",
+					     "setCurrentScene",      "getTransitions",   "getCurrentTransition",
+					     "setCurrentTransition", "getSourceVisible", "setSourceVisible"};
 
 void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, CefRefPtr<CefV8Context> context)
 {

--- a/browser-client.cpp
+++ b/browser-client.cpp
@@ -191,6 +191,32 @@ bool BrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefR
 			} else {
 				obs_frontend_set_current_scene(source);
 			}
+		} else if (name == "setSourceVisible") {
+			const std::string scene_name = input_args->GetString(1).ToString();
+			const std::string source_name = input_args->GetString(2).ToString();
+			const std::string visible = input_args->GetBool(3);
+			OBSSourceAutoRelease *scene = obs_get_source_by_name(scene_name.c_str());
+			if (!scene) {
+				blog(LOG_WARNING,
+				     "Browser source '%s' tried to set the visibility of a scene item in scene '%s' which doesn't exist",
+				     obs_source_get_name(bs->source), scene_name.c_str());
+				break;
+			}
+			if (!obs_source_is_scene(scene)) {
+				blog(LOG_WARNING,
+				     "Browser source '%s' tried to set the visibility of a scene item in scene '%s' which isn't a scene",
+				     obs_source_get_name(bs->source), scene_name.c_str());
+				break;
+			}
+			obs_sceneitem_t *item =
+				obs_scene_find_source_recursive(obs_scene_from_source(scene), source_name.c_str());
+			if (!item) {
+				blog(LOG_WARNING,
+				     "Browser source '%s' tried to set the visibility of scene item '%s' which doesn't exist in scene '%s'",
+				     obs_source_get_name(bs->source), source_name.c_str(), scene_name.c_str());
+				break;
+			}
+			obs_sceneitem_set_visible(item, visible);
 		} else if (name == "setCurrentTransition") {
 			const std::string transition_name = input_args->GetString(1).ToString();
 			obs_frontend_source_list transitions = {};
@@ -244,6 +270,23 @@ bool BrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefR
 			json = {{"name", name},
 				{"width", obs_source_get_width(current_scene)},
 				{"height", obs_source_get_height(current_scene)}};
+		} else if (name == "getSourceVisible") {
+			const std::string scene_name = input_args->GetString(1).ToString();
+			const std::string source_name = input_args->GetString(2).ToString();
+			OBSSourceAutoRelease *scene = obs_get_source_by_name(scene_name.c_str());
+
+			if (!scene)
+				return false;
+
+			if (!obs_source_is_scene(scene))
+				return false;
+
+			obs_sceneitem_t *item =
+				obs_scene_find_source_recursive(obs_scene_from_source(scene), source_name.c_str());
+			if (!item)
+				return false;
+
+			json = obs_sceneitem_visible(item);
 		} else if (name == "getTransitions") {
 			struct obs_frontend_source_list list = {};
 			obs_frontend_get_transitions(&list);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This exposes a javascript function for determining the visiblity of arbitrary OBS sources and another for modifying said visibility. These functions are available to browser sources with the requisite permissions: ReadUser or higher for `getSourceVisible`, Advanced or higher for `setSourceVisible`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Excerpt from https://github.com/obsproject/obs-browser/issues/73#issuecomment-3190645799:

> I've found myself surprised to find that there's no `setVisibilityState` or `setSourceVisibility`. I was hoping to hide the browser source when an html video element finishes playing so that the source's hide transition can be triggered, and the automation software I use can later show the source again with a new URL.
> 
> I could see someone arguing that `getSourceVisibility` would make sense too, as the visibility of another source/non-browser source can't be determined [using the browser's Document Visibility API].

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I'm still working on figuring out how to build _obs-browser_, so the change hasn't been tested yet. I'd appreciate any tips you have regarding this as it appears the _obs-studio_ build process has changed since the last time the _obs-browser_ build documentation was updated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested. ← working on this, see above
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation (that I'm aware of).
