### PR TITLE
Set disable-gpu-process-crash-limit flag for CEF

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -97,6 +97,9 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 #elif !defined(_WIN32)
 	command_line->AppendSwitchWithValue("ozone-platform", wayland ? "wayland" : "x11");
 #endif
+
+	// If the GPU crashes too much, don't crash OBS as well - better to just have broken sources
+	command_line->AppendSwitch("disable-gpu-process-crash-limit");
 }
 
 std::vector<std::string> exposedFunctions = {"getControlLevel",     "getCurrentScene",  "getStatus",


### PR DESCRIPTION
### Description
One of our top OBS crashers is CEF crashing the entire process if its GPU process crashes too much. Until we can figure out why the GPU is crashing so much for some users, avoid crashing OBS entirely and just have broken browser sources instead.

### Motivation and Context
Avoid CEF bringing down OBS on GPU errors.

### How Has This Been Tested?
Hasn't - I am unable to reproduce the GPU issues.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
