### PR TITLE
Allow WebSocket requests over the network

### DIFF
--- a/browser-app.cpp
+++ b/browser-app.cpp
@@ -134,7 +134,7 @@ void BrowserApp::OnBeforeCommandLineProcessing(const CefString &, CefRefPtr<CefC
 	// See https://github.com/chromiumembedded/cef/issues/3966 for 'StorageNotificationService' requirement.
 	constexpr std::string_view kDefaultDisabledFeatures{
 		"CalculateNativeWinOcclusion,GlobalShortcutsPortal,HardwareMediaKeyHandling,LiveCaption,"
-		"MediaRouter,StorageNotificationService,WebBluetooth,"
+		"LocalNetworkAccessChecksWebSockets,MediaRouter,StorageNotificationService,WebBluetooth,"
 		"EnableWindowsGamingInputDataFetcher"};
 
 	std::string disableFeatures{};


### PR DESCRIPTION

### Description

Well this solution ended up being different than I expected.

I had previously prepared https://github.com/WizardCM/obs-browser/commit/4c65eaaf4044240f16e15a0258db3023b79945d7 which would show a permission request dialog.
However, in my testing today, this dialog **does not** get triggered for a website attempting to access the local network for WebSockets, at least on CEF 150. **Neither** `OnRequestMediaAccessPermission` nor `OnShowPermissionPrompt` get called.

This is strange, because on a shipping version of Google Chrome, a permission dialog is displayed, and clicking Allow enables the connection. **Further digging is required but is not a blocker for this PR.**

The flow in CEF works like so
* Microphone/Webcam permissions go through `OnRequestMediaAccessPermission`
* Most other permissions go through `OnShowPermissionPrompt`
* Local network WebSocket is tied to https://github.com/chromium/chromium/blob/8408977/services/network/public/cpp/features.cc#L273-L279

Webcam and Microphone seem to continue to work via `--enable-media-stream` per [this documentation](https://cef-builds.spotifycdn.com/docs/150.0/classCefPermissionHandler.html#a05723b8cdd0a3f410ea52d05e2a41e16), which I have verified is true. This behaviour is unchanged before or after this PR.
> With Alloy style, default handling will deny the request. This method will not be called if the `--enable-media-stream` command-line switch is used to grant all permissions.

### Motivation and Context

Retain pre-Chrome-runtime behaviour for all permissions (for now). In this case, the ability for a browser source or dock's webpage to make outgoing WebSocket requests.

Fixes `ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`

We do not want to provide regressions while a better solution is devised.

At the same time, we also don't want to open too many security holes by using broad toggles.

### How Has This Been Tested?

Launch with CEF 150 on Windows pointed to `https://obs.wesbos.com/`

Attempt to log in.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.